### PR TITLE
Only deploy tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,11 @@ workflows:
               only: master
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
-      - deploy:
+      - deploy: # Only deploy tagged releases
           requires:
             - test
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Prevent the deploy job from triggering for master

See https://circleci.com/docs/2.0/workflows/#git-tag-job-execution