### PR TITLE
[WIP] Traverse immediate child associations by default

### DIFF
--- a/pkg/instance/describe_cmd.go
+++ b/pkg/instance/describe_cmd.go
@@ -63,6 +63,12 @@ func (c *describeCmd) describe(name string) error {
 
 	output.WriteInstanceDetails(instance)
 
+	bindings, err := traverse.InstanceToBindings(c.cl, instance)
+	if err != nil {
+		return err
+	}
+	output.WriteAssociatedBindings(bindings)
+
 	if c.traverse {
 		class, plan, broker, err := traverse.InstanceParentHierarchy(c.cl, instance)
 		if err != nil {

--- a/pkg/output/binding.go
+++ b/pkg/output/binding.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"fmt"
+
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 )
 
@@ -54,5 +56,27 @@ func WriteBindingDetails(binding *v1beta1.ServiceBinding) {
 		{"Instance:", binding.Spec.ServiceInstanceRef.Name},
 	})
 
+	t.Render()
+}
+
+// WriteAssociatedBindings prints a list of bindings associated with an instance.
+func WriteAssociatedBindings(bindings []v1beta1.ServiceBinding) {
+	fmt.Println("\nBindings:")
+	if len(bindings) == 0 {
+		fmt.Println("No bindings defined")
+		return
+	}
+
+	t := NewListTable()
+	t.SetHeader([]string{
+		"Name",
+		"Status",
+	})
+	for _, binding := range bindings {
+		t.Append([]string{
+			binding.Name,
+			getBindingStatusShort(binding.Status),
+		})
+	}
 	t.Render()
 }


### PR DESCRIPTION
- [x] `svc-cat describe instance <name>` prints child bindings by default
- [ ] `svc-cat describe plan <name>` shouldn't hide the instances behind `--traverse` and instead should print the parent class and broker.
- [ ] `svc-cat describe class <name>` shouldn't hide the plans behind `--traverse` and should print the parent broker.

Closes #22.