### PR TITLE
Revamp the readme to show examples for common scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You will need to find a permanent location for it and add it to your PATH.
 This CLI is called `svcat` on the command line. Run `svcat -h` to see the available
 commands.
 
-Below are some common tasks made easy with `svcat`:
+Below are some common tasks made easy with `svcat`. The example output assumes that [Open Service Broker for Azure](https://github.com/Azure/open-service-broker-azure/) is installed on the cluster.
 
 ## Find brokers installed on the cluster
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/Azure/service-catalog-cli.svg?style=svg&circle-token=98d6d64c981e70b76736fb3f05a0b41b4fec47cf)](https://circleci.com/gh/Azure/service-catalog-cli)
 
-This project is a command line interface (CLI) for interacting with 
+This project is a command line interface (CLI) for interacting with
 [Kubernetes Service Catalog](https://github.com/kubernetes-incubator/service-catalog)
 resources.
 
@@ -10,7 +10,7 @@ resources.
 |---|---|
 
 The goal of the CLI is to provide an easy user interface for Service Catalog users
-to inspect and modify the state of the resources in the system.
+to inspect and modify the state of resources in the system.
 
 # Install
 
@@ -31,7 +31,7 @@ $env:PATH += ";${pwd}\bin"
 svcat --version
 ```
 
-The snippet above adds a directory to your PATH for the current session only. 
+The snippet above adds a directory to your PATH for the current session only.
 You will need to find a permanent location for it and add it to your PATH.
 
 ## Manual
@@ -44,58 +44,121 @@ You will need to find a permanent location for it and add it to your PATH.
 
 # Use
 
-This CLI is called `svcat` on the command line. See below for a description 
-of the commands that `svcat` offers.
+This CLI is called `svcat` on the command line. Run `svcat -h` to see the available
+commands.
 
-## Commands for `ClusterServiceBroker`s
+Below are some common tasks made easy with `svcat`:
 
-To list all the brokers in the cluster:
+## Find brokers installed on the cluster
 
 ```console
-svcat get brokers
+$ svcat get brokers
 ```
 
-To get the status of an individual broker:
+## List available service classes
 
 ```console
-svcat get broker <broker name>
+$ svcat get classes
+            NAME                      DESCRIPTION                             UUID
++--------------------------+--------------------------------+--------------------------------------+
+  azure-rediscache           Azure Redis Cache                0346088a-d4b2-4478-aa32-f18e295ec1d9
+  azure-storage              Azure Storage                    2e2fc314-37b6-4587-8127-8f9ee8b33fea
+  azure-aci                  Azure Container Instance         451d5d19-4575-4d4a-9474-116f705ecc95
+  azure-cosmos-document-db   Azure DocumentDB provided by     6330de6f-a561-43ea-a15e-b99f44d183e6
+                             CosmosDB and accessible via
+                             SQL (DocumentDB), Gremlin
+                             (Graph), and Table (Key-Value)
+                             APIs
+  azure-servicebus           Azure Service Bus                6dc44338-2f13-4bc5-9247-5b1b3c5462d3
+  azure-eventhub             Azure Event Hub Service          7bade660-32f1-4fd7-b9e6-d416d975170b
+  azure-cosmos-mongo-db      MongoDB on Azure provided by     8797a079-5346-4e84-8018-b7d5ea5c0e3a
+                             CosmosDB
+  azure-mysqldb              Azure Database for MySQL         997b8372-8dac-40ac-ae65-758b4a5075a5
+                             Service
+  azure-postgresqldb         Azure Database for PostgreSQL    b43b4bba-5741-4d98-a10b-17dc5cee0175
+                             Service
+  azuresearch                Azure Search                     c54902aa-3027-4c5c-8e96-5b3d3b452f7f
+  azure-keyvault             Azure Key Vault                  d90c881e-c9bb-4e07-a87b-fcfe87e03276
+  azure-sqldb                Azure SQL Database Service       fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5
 ```
 
-## Commands for `ClusterServiceClass`es
-
-To get a list of all the `ClusterServiceClass`es in the cluster (i.e. the catalog):
+## View service plans associated with a class
 
 ```console
-svcat get classes
+$ svcat describe class azure-mysqldb --traverse
+  Name:          azure-mysqldb
+  Description:   Azure Database for MySQL Service
+  UUID:          997b8372-8dac-40ac-ae65-758b4a5075a5
+  Status:        Active
+  Tags:          Azure, MySQL, Database
+
+Plans:
+     NAME             DESCRIPTION
++-------------+-------------------------+
+  standard800   Standard Tier, 800 DTUs
+  basic100      Basic Tier, 100 DTUs
+  basic50       Basic Tier, 50 DTUs.
+  standard200   Standard Tier, 200 DTUs
+  standard400   Standard Tier, 400 DTUs
+  standard100   Standard Tier, 100 DTUs
 ```
 
-## Commands for `ClusterServicePlan`s
-
-To get a list of all the `ClusterServicePlan`s in the cluster (i.e. the catalog):
+## View all instances of a service plan on the cluster
 
 ```console
-svcat get plans
+$ svcat describe plan standard800 --traverse
+  Name:          standard800
+  Description:   Standard Tier, 800 DTUs
+  UUID:          08e4b43a-36bc-447e-a81f-8202b13e339c
+  Class:         azure-mysqldb
+  Status:        Active
+  Free:          false
+
+Instances:
+                NAME                  NAMESPACE   STATUS
++-----------------------------------+-----------+--------+
+  deepthoughts-ghost-mysql-instance   cms         Ready
+  ponycms-wordpress-mysql-instance    cms         Ready
 ```
 
-## Commands for `ServiceInstance`s
-
-To get a list of all the `ServiceInstance`s in a namespace:
+## List all service instances in a namespace
 
 ```console
-svcat get instances -n <namespace>
+$ svcat get bindings --namespace cms
+                NAME                 NAMESPACE               INSTANCE                STATUS
++----------------------------------+-----------+-----------------------------------+--------+
+  deepthoughts-ghost-mysql-binding   cms         deepthoughts-ghost-mysql-instance   Ready
+  ponycms-wordpress-mysql-binding    cms         ponycms-wordpress-mysql-instance    Ready
 ```
 
-## Commands for `ServiceBinding`s
-
-To get a list of all the `ServiceBinding`s in a namespace:
+## View the details of a service instance
 
 ```console
-svcat get bindings -n <namespace>
+$ svcat describe instance ponycms-wordpress-mysql-instance --traverse
+  Name:        ponycms-wordpress-mysql-instance
+  Namespace:   cms
+  Status:      Ready - The instance was provisioned successfully @ 2017-11-30 13:11:49 -0600 CST
+  Class:       azure-mysqldb
+  Plan:        standard800
+
+Class:
+  Name:     azure-mysqldb
+  UUID:     997b8372-8dac-40ac-ae65-758b4a5075a5
+  Status:   Active
+
+Plan:
+  Name:     standard800
+  UUID:     08e4b43a-36bc-447e-a81f-8202b13e339c
+  Status:   Active
+
+Broker:
+  Name:     asb
+  Status:   Ready
 ```
 
 # Contributing
 
-For details on how to contribute to this project, please see 
+For details on how to contribute to this project, please see
 [contributing.md](./docs/contributing.md).
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/pkg/broker/sync_cmd.go
+++ b/pkg/broker/sync_cmd.go
@@ -13,7 +13,7 @@ type syncCmd struct {
 	cl *clientset.Clientset
 }
 
-// NewSyncCmd builds a "svc-cat sync broker" command
+// NewSyncCmd builds a "svcat sync broker" command
 func NewSyncCmd(cl *clientset.Clientset) *cobra.Command {
 	syncCmd := syncCmd{cl: cl}
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
Continuing https://github.com/Azure/service-catalog-cli/pull/50 after the great fork snafu of 2017.
___

For now I'm directing people to svc-cat -h instead of trying to manually duplicate the help text on the readme.