### PR TITLE
Tweak build script / version command for homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ SHELL := /bin/bash
 COMMIT ?= $(shell git rev-parse --verify --short HEAD)
 VERSION ?= $(shell git describe --tags --dirty='+dev' 2> /dev/null)
 LDFLAGS = -w -X main.commit=$(COMMIT) -X main.version=$(VERSION)
-XBUILD = go build -a -tags netgo -ldflags '$(LDFLAGS)'
+GOBUILD = CGO_ENABLED=0 go build -a -tags netgo -ldflags '$(LDFLAGS)'
 RELEASE_DIR = bin/$(VERSION)
 
 build:
-	go build -o bin/svcat ./cmd/svcat
+	$(GOBUILD) -o bin/svcat ./cmd/svcat
 
 linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(XBUILD) -o $(RELEASE_DIR)/Linux/x86_64/svcat ./cmd/svcat
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(RELEASE_DIR)/Linux/x86_64/svcat ./cmd/svcat
 	cd $(RELEASE_DIR)/Linux/x86_64 && shasum -a 256 svcat > svcat.sha256
 
 darwin:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(XBUILD) -o $(RELEASE_DIR)/Darwin/x86_64/svcat ./cmd/svcat
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $(RELEASE_DIR)/Darwin/x86_64/svcat ./cmd/svcat
 	cd $(RELEASE_DIR)/Darwin/x86_64 && shasum -a 256 svcat > svcat.sha256
 
 windows:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(XBUILD) -o $(RELEASE_DIR)/Windows/x86_64/svcat.exe ./cmd/svcat
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $(RELEASE_DIR)/Windows/x86_64/svcat.exe ./cmd/svcat
 	cd $(RELEASE_DIR)/Windows/x86_64 && shasum -a 256 svcat.exe > svcat.exe.sha256
 
 cross-build: linux darwin windows

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
-COMMIT = $(shell git rev-parse --verify --short HEAD)
-VERSION = $(shell git describe --tags --dirty='+dev' 2> /dev/null)
+COMMIT ?= $(shell git rev-parse --verify --short HEAD)
+VERSION ?= $(shell git describe --tags --dirty='+dev' 2> /dev/null)
 LDFLAGS = -w -X main.commit=$(COMMIT) -X main.version=$(VERSION)
 XBUILD = go build -a -tags netgo -ldflags '$(LDFLAGS)'
 RELEASE_DIR = bin/$(VERSION)

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -34,7 +34,11 @@ func main() {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Version {
-				fmt.Printf("svcat %s (%s)\n", version, commit)
+				if commit == "" { // commit is empty for Homebrew builds
+					fmt.Printf("svcat %s\n", version)
+				} else {
+					fmt.Printf("svcat %s (%s)\n", version, commit)
+				}
 				return nil
 			}
 


### PR DESCRIPTION
Homebrew prefers to not build from git, instead downloading the compressed archive and passing the version into the make command.

## Homebrew
```console
$ svcat --version
svcat v1.2.3
```

## Other

```console
$ svcat --version
svcat v1.2.3 (abc1234)
```

A few other minor tweaks
* allow setting VERSION and COMMIT when invoking make
* disable CGO for local builds
* pass ldflags to local builds