### PR TITLE
Provision command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -166,12 +166,14 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "f62e98d28ab7ad31d707ba837a966378465c7b57"
+  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
+  version = "v0.0.1"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
 
 [[projects]]
   name = "golang.org/x/crypto"
@@ -230,6 +232,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a77c8dce752f3103cd264a0e7cc806b3e18e13442f7c4aa7b5ee370f033e0925"
+  inputs-digest = "cb95d449bf541ac0cb182718a309083ad7be9b887fc2ac353f75e9ec5e57def5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,3 +9,8 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "~0.8.0"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version= "~0.0.1"
+

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Plans:
   standard100   Standard Tier, 100 DTUs
 ```
 
+## Provision a service
+
+```console
+$ svcat provision quickstart-wordpress-mysql-instance \
+    --class azure-mysqldb --plan standard800 \
+    -p location=eastus -p resourceGroup=default
+```
+
 ## View all instances of a service plan on the cluster
 
 ```console

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -74,6 +74,7 @@ func buildRootCommand() *cobra.Command {
 
 	cmd.AddCommand(newGetCmd(cxt))
 	cmd.AddCommand(newDescribeCmd(cxt))
+	cmd.AddCommand(instance.NewProvisionCmd(cxt))
 	cmd.AddCommand(newSyncCmd(cxt))
 
 	return cmd

--- a/pkg/class/class.go
+++ b/pkg/class/class.go
@@ -14,7 +14,7 @@ const (
 	fieldServiceClassRef = "spec.clusterServiceClassRef.name"
 )
 
-func retrieveByName(cl *clientset.Clientset, name string) (*v1beta1.ClusterServiceClass, error) {
+func RetrieveByName(cl *clientset.Clientset, name string) (*v1beta1.ClusterServiceClass, error) {
 	opts := v1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(fieldExternalName, name).String(),
 	}

--- a/pkg/class/describe_cmd.go
+++ b/pkg/class/describe_cmd.go
@@ -63,7 +63,7 @@ func (c *describeCmd) describe(key string) error {
 	if c.lookupByUUID {
 		class, err = retrieveByUUID(c.Client, key)
 	} else {
-		class, err = retrieveByName(c.Client, key)
+		class, err = RetrieveByName(c.Client, key)
 	}
 	if err != nil {
 		return err

--- a/pkg/class/get_cmd.go
+++ b/pkg/class/get_cmd.go
@@ -66,7 +66,7 @@ func (c *getCmd) get(key string) error {
 	if c.lookupByUUID {
 		class, err = retrieveByUUID(c.Client, key)
 	} else {
-		class, err = retrieveByName(c.Client, key)
+		class, err = RetrieveByName(c.Client, key)
 	}
 	if err != nil {
 		return err

--- a/pkg/instance/describe_cmd.go
+++ b/pkg/instance/describe_cmd.go
@@ -51,8 +51,8 @@ func (c *describeCmd) run(args []string) error {
 		return fmt.Errorf("name is required")
 	}
 
-	key := args[0]
-	return c.describe(key)
+	name := args[0]
+	return c.describe(name)
 }
 
 func (c *describeCmd) describe(name string) error {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -1,11 +1,19 @@
 package instance
 
 import (
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	waitForStatusPollInterval = time.Second
+	waitForStatusRetries      = 5
 )
 
 func retrieveAll(cl *clientset.Clientset, ns string) (*v1beta1.ServiceInstanceList, error) {
@@ -22,5 +30,56 @@ func retrieveByName(cl *clientset.Clientset, ns, name string) (*v1beta1.ServiceI
 	if err != nil {
 		return nil, fmt.Errorf("unable to get instance '%s.%s' (%s)", ns, name, err)
 	}
+	return instance, nil
+}
+
+func provision(cl *clientset.Clientset, namespace, instanceName, className, planName string, params map[string]string,
+) (*v1beta1.ServiceInstance, error) {
+	paramsJson, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal the request parameters %v (%s)", params, err)
+	}
+
+	request := &v1beta1.ServiceInstance{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ClusterServiceClassExternalName: className,
+				ClusterServicePlanExternalName:  planName,
+			},
+			Parameters: &runtime.RawExtension{
+				Raw: paramsJson,
+			},
+		},
+	}
+
+	result, err := cl.ServicecatalogV1beta1().ServiceInstances(namespace).Create(request)
+	if err != nil {
+		return nil, fmt.Errorf("provision request failed (%s)", err)
+	}
+	return result, nil
+}
+
+// waitForStatus to be populated on an instance.
+// The result of some operations only include a subset of the instance fields, notably missing status.
+func waitForStatus(cl *clientset.Clientset, instance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
+	var err error
+
+	for i := 0; i < waitForStatusRetries; i++ {
+		if len(instance.Status.Conditions) > 0 {
+			break
+		}
+
+		time.Sleep(waitForStatusPollInterval)
+
+		instance, err = retrieveByName(cl, instance.Namespace, instance.Name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return instance, nil
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -3,17 +3,11 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-)
-
-const (
-	waitForStatusPollInterval = time.Second
-	waitForStatusRetries      = 5
 )
 
 func retrieveAll(cl *clientset.Clientset, ns string) (*v1beta1.ServiceInstanceList, error) {
@@ -61,25 +55,4 @@ func provision(cl *clientset.Clientset, namespace, instanceName, className, plan
 		return nil, fmt.Errorf("provision request failed (%s)", err)
 	}
 	return result, nil
-}
-
-// waitForStatus to be populated on an instance.
-// The result of some operations only include a subset of the instance fields, notably missing status.
-func waitForStatus(cl *clientset.Clientset, instance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
-	var err error
-
-	for i := 0; i < waitForStatusRetries; i++ {
-		if len(instance.Status.Conditions) > 0 {
-			break
-		}
-
-		time.Sleep(waitForStatusPollInterval)
-
-		instance, err = retrieveByName(cl, instance.Namespace, instance.Name)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return instance, nil
 }

--- a/pkg/instance/provision_cmd.go
+++ b/pkg/instance/provision_cmd.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Azure/service-catalog-cli/pkg/command"
 	"github.com/Azure/service-catalog-cli/pkg/output"
-	"github.com/Azure/service-catalog-cli/pkg/params"
+	"github.com/Azure/service-catalog-cli/pkg/parameters"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ func (c *provisonCmd) run(args []string) error {
 	}
 	name := args[0]
 
-	params, err := params.ParseVariableAssignments(c.params)
+	params, err := parameters.ParseVariableAssignments(c.params)
 	if err != nil {
 		return fmt.Errorf("invalid --param value (%s)", err)
 	}

--- a/pkg/instance/provision_cmd.go
+++ b/pkg/instance/provision_cmd.go
@@ -63,11 +63,6 @@ func (c *provisonCmd) provision(instanceName string) error {
 		return err
 	}
 
-	instance, err = waitForStatus(c.Client, instance)
-	if err != nil {
-		return err
-	}
-
 	output.WriteInstanceDetails(c.Output, instance)
 
 	return nil

--- a/pkg/instance/provision_cmd.go
+++ b/pkg/instance/provision_cmd.go
@@ -47,18 +47,18 @@ func (c *provisonCmd) run(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("name is required")
 	}
+	name := args[0]
 
-	key := args[0]
-	return c.provision(key)
-}
-
-func (c *provisonCmd) provision(instanceName string) error {
 	params, err := params.ParseVariableAssignments(c.params)
 	if err != nil {
 		return fmt.Errorf("invalid --param value (%s)", err)
 	}
 
-	instance, err := provision(c.Client, c.ns, instanceName, c.className, c.planName, params)
+	return c.provision(name, params)
+}
+
+func (c *provisonCmd) provision(name string, params map[string]string) error {
+	instance, err := provision(c.Client, c.ns, name, c.className, c.planName, params)
 	if err != nil {
 		return err
 	}

--- a/pkg/instance/provision_cmd.go
+++ b/pkg/instance/provision_cmd.go
@@ -1,0 +1,74 @@
+package instance
+
+import (
+	"fmt"
+
+	"github.com/Azure/service-catalog-cli/pkg/command"
+	"github.com/Azure/service-catalog-cli/pkg/output"
+	"github.com/Azure/service-catalog-cli/pkg/params"
+	"github.com/spf13/cobra"
+)
+
+type provisonCmd struct {
+	*command.Context
+	ns        string
+	className string
+	planName  string
+	params    []string
+}
+
+// NewProvisionCmd builds a "svcat provision" command
+func NewProvisionCmd(cxt *command.Context) *cobra.Command {
+	provisionCmd := &provisonCmd{Context: cxt}
+	cmd := &cobra.Command{
+		Use:   "provision NAME",
+		Short: "Create a new instance of a service",
+		Example: `
+  svcat provision wordpress-mysql-instance --class azure-mysqldb --plan standard800 -p location=eastus -p sslEnforcement=disabled
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return provisionCmd.run(args)
+		},
+	}
+	cmd.Flags().StringVarP(&provisionCmd.ns, "namespace", "n", "default",
+		"The namespace in which to create the instance")
+	cmd.Flags().StringVar(&provisionCmd.className, "class", "",
+		"The class name")
+	cmd.MarkFlagRequired("class")
+	cmd.Flags().StringVar(&provisionCmd.planName, "plan", "",
+		"The plan name")
+	cmd.MarkFlagRequired("plan")
+	cmd.Flags().StringArrayVarP(&provisionCmd.params, "params", "p", nil,
+		"Additional parameters to use when provisioning the service")
+	return cmd
+}
+
+func (c *provisonCmd) run(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("name is required")
+	}
+
+	key := args[0]
+	return c.provision(key)
+}
+
+func (c *provisonCmd) provision(instanceName string) error {
+	params, err := params.ParseVariableAssignments(c.params)
+	if err != nil {
+		return fmt.Errorf("invalid --param value (%s)", err)
+	}
+
+	instance, err := provision(c.Client, c.ns, instanceName, c.className, c.planName, params)
+	if err != nil {
+		return err
+	}
+
+	instance, err = waitForStatus(c.Client, instance)
+	if err != nil {
+		return err
+	}
+
+	output.WriteInstanceDetails(c.Output, instance)
+
+	return nil
+}

--- a/pkg/instance/provision_cmd.go
+++ b/pkg/instance/provision_cmd.go
@@ -22,7 +22,7 @@ type provisonCmd struct {
 func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 	provisionCmd := &provisonCmd{Context: cxt}
 	cmd := &cobra.Command{
-		Use:   "provision NAME",
+		Use:   "provision NAME --plan PLAN --class CLASS",
 		Short: "Create a new instance of a service",
 		Example: `
   svcat provision wordpress-mysql-instance --class azure-mysqldb --plan standard800 -p location=eastus -p sslEnforcement=disabled
@@ -35,10 +35,10 @@ func NewProvisionCmd(cxt *command.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&provisionCmd.ns, "namespace", "n", "default",
 		"The namespace in which to create the instance")
 	cmd.Flags().StringVar(&provisionCmd.className, "class", "",
-		"The class name")
+		"The class name (Required)")
 	cmd.MarkFlagRequired("class")
 	cmd.Flags().StringVar(&provisionCmd.planName, "plan", "",
-		"The plan name")
+		"The plan name (Required)")
 	cmd.MarkFlagRequired("plan")
 	cmd.Flags().StringArrayVarP(&provisionCmd.params, "param", "p", nil,
 		"Additional parameter to use when provisioning the service, format: NAME=VALUE")

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -22,6 +22,9 @@ func formatStatusShort(condition string, conditionStatus v1beta1.ConditionStatus
 
 func formatStatusFull(condition string, conditionStatus v1beta1.ConditionStatus, reason string, message string, timestamp v1.Time) string {
 	status := formatStatusShort(condition, conditionStatus, reason)
+	if status == "" {
+		return ""
+	}
 	message = strings.TrimRight(message, ".")
 	return fmt.Sprintf("%s - %s @ %s", status, message, timestamp)
 }

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -2,8 +2,11 @@ package parameters
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+var keymapRegex = regexp.MustCompile(`^([^\[]+)\[(.+)\]\s*$`)
 
 // ParseVariableAssignment converts a string array of variable assignments
 // into a map of keys and values
@@ -28,4 +31,33 @@ func ParseVariableAssignments(params []string) (map[string]string, error) {
 	}
 
 	return variables, nil
+}
+
+// ParseKeyMaps converts a string array of key lookups
+// into a map of the map name and key
+// Example:
+// [a[b] mysecret[foo.txt]] becomes map[a:b mysecret:foo.txt]
+func ParseKeyMaps(params []string) (map[string]string, error) {
+	keymap := map[string]string{}
+
+	for _, p := range params {
+		parts := keymapRegex.FindStringSubmatch(p)
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid parameter (%s), must be in MAP[KEY] format", p)
+		}
+
+		mapName := strings.TrimSpace(parts[1])
+		if mapName == "" {
+			return nil, fmt.Errorf("invalid parameter (%s), map is requried", p)
+		}
+
+		key := strings.TrimSpace(parts[2])
+		if key == "" {
+			return nil, fmt.Errorf("invalid parameter (%s), key is required", p)
+		}
+
+		keymap[mapName] = key
+	}
+
+	return keymap, nil
 }

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -1,4 +1,4 @@
-package params
+package parameters
 
 import (
 	"fmt"

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -3,6 +3,8 @@ package parameters
 import (
 	"reflect"
 	"testing"
+
+	_ "github.com/Azure/service-catalog-cli/internal/test"
 )
 
 func TestParseVariableAssignments(t *testing.T) {

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -40,5 +40,50 @@ func TestParseVariableAssignments_MissingVariableName(t *testing.T) {
 	if err == nil {
 		t.Fatal("should have failed due to a missing variable name")
 	}
+}
 
+func TestParseKeyMaps(t *testing.T) {
+	testcases := []struct {
+		Name, Raw, MapName, Key string
+	}{
+		{"simple", "a[b]", "a", "b"},
+		{"multiple brackets signs", "c[[d]]", "c", "[d]"},
+		{"extra whitespace", " a [ b ] ", "a", "b"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			params := []string{tc.Raw}
+
+			got, err := ParseKeyMaps(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := map[string]string{tc.MapName: tc.Key}
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)
+			}
+		})
+	}
+}
+
+func TestParseKeyMaps_InvalidInput(t *testing.T) {
+	testcases := []struct {
+		Name, Raw string
+	}{
+		{"missing map", "[b]"},
+		{"missing key", "a[]"},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			params := []string{tc.Raw}
+
+			result, err := ParseKeyMaps(params)
+			if err == nil {
+				t.Fatalf("expected parse to fail for %s but got %v", tc.Raw, result)
+			}
+		})
+	}
 }

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -1,4 +1,4 @@
-package params
+package parameters
 
 import (
 	"reflect"

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -1,0 +1,31 @@
+package params
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseVariableAssignment converts a string array of variable assignments
+// into a map of keys and values
+// Example:
+// [a=b c=abc1232===] becomes map[a:b c:abc1232===]
+func ParseVariableAssignments(params []string) (map[string]string, error) {
+	variables := map[string]string{}
+
+	for _, p := range params {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid parameter (%s), must be in name=value format", p)
+		}
+
+		variable := strings.TrimSpace(parts[0])
+		if variable == "" {
+			return nil, fmt.Errorf("invalid parameter (%s), variable name is requried", p)
+		}
+		value := strings.TrimSpace(parts[1])
+
+		variables[variable] = value
+	}
+
+	return variables, nil
+}

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -1,0 +1,44 @@
+package params
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseVariableAssignments(t *testing.T) {
+	testcases := []struct {
+		Name, Raw, Variable, Value string
+	}{
+		{"simple", "a=b", "a", "b"},
+		{"multiple equal signs", "c=abc1232===", "c", "abc1232==="},
+		{"empty value", "d=", "d", ""},
+		{"extra whitespace", " a = b ", "a", "b"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			params := []string{tc.Raw}
+
+			got, err := ParseVariableAssignments(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := map[string]string{tc.Variable: tc.Value}
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("%s\nexpected:\n\t%v\ngot:\n\t%v\n", tc.Raw, want, got)
+			}
+		})
+	}
+}
+
+func TestParseVariableAssignments_MissingVariableName(t *testing.T) {
+	params := []string{"=b"}
+
+	_, err := ParseVariableAssignments(params)
+	if err == nil {
+		t.Fatal("should have failed due to a missing variable name")
+	}
+
+}

--- a/pkg/plan/describe_cmd.go
+++ b/pkg/plan/describe_cmd.go
@@ -63,7 +63,7 @@ func (c *describeCmd) describe(key string) error {
 	if c.lookupByUUID {
 		plan, err = retrieveByUUID(c.Client, key)
 	} else {
-		plan, err = retrieveByName(c.Client, key)
+		plan, err = RetrieveByName(c.Client, key)
 	}
 	if err != nil {
 		return err

--- a/pkg/plan/get_cmd.go
+++ b/pkg/plan/get_cmd.go
@@ -72,7 +72,7 @@ func (c *getCmd) get(key string) error {
 	if c.lookupByUUID {
 		plan, err = retrieveByUUID(c.Client, key)
 	} else {
-		plan, err = retrieveByName(c.Client, key)
+		plan, err = RetrieveByName(c.Client, key)
 	}
 
 	// Retrieve the class as well because plans don't have the external class name

--- a/pkg/plan/plan.go
+++ b/pkg/plan/plan.go
@@ -13,7 +13,7 @@ const (
 	fieldExternalName = "spec.externalName"
 )
 
-func retrieveByName(cl *clientset.Clientset, name string) (*v1beta1.ClusterServicePlan, error) {
+func RetrieveByName(cl *clientset.Clientset, name string) (*v1beta1.ClusterServicePlan, error) {
 	opts := v1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(fieldExternalName, name).String(),
 	}

--- a/vendor/github.com/spf13/cobra/.travis.yml
+++ b/vendor/github.com/spf13/cobra/.travis.yml
@@ -1,11 +1,10 @@
 language: go
-go:
-  - 1.4.3
-  - 1.5.4
-  - 1.6.3
-  - tip
 
 matrix:
+  include:
+    - go: 1.7.6
+    - go: 1.8.3
+    - go: tip
   allow_failures:
     - go: tip
 
@@ -16,3 +15,7 @@ before_install:
 script:
   - PATH=$PATH:$PWD/bin go test -v ./...
   - go build
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - if [ -z $NOVET ]; then
+      diff -u <(echo -n) <(go tool vet . 2>&1 | grep -vE 'ExampleCommand|bash_completions.*Fprint');
+    fi

--- a/vendor/github.com/spf13/cobra/README.md
+++ b/vendor/github.com/spf13/cobra/README.md
@@ -8,6 +8,7 @@ Many of the most widely used Go projects are built using Cobra including:
 * [Hugo](http://gohugo.io)
 * [rkt](https://github.com/coreos/rkt)
 * [etcd](https://github.com/coreos/etcd)
+* [Moby (former Docker)](https://github.com/moby/moby)
 * [Docker (distribution)](https://github.com/docker/distribution)
 * [OpenShift](https://www.openshift.com/)
 * [Delve](https://github.com/derekparker/delve)
@@ -15,16 +16,36 @@ Many of the most widely used Go projects are built using Cobra including:
 * [CockroachDB](http://www.cockroachlabs.com/)
 * [Bleve](http://www.blevesearch.com/)
 * [ProjectAtomic (enterprise)](http://www.projectatomic.io/)
-* [Parse (CLI)](https://parse.com/)
 * [GiantSwarm's swarm](https://github.com/giantswarm/cli)
 * [Nanobox](https://github.com/nanobox-io/nanobox)/[Nanopack](https://github.com/nanopack)
-
+* [rclone](http://rclone.org/)
+* [nehm](https://github.com/bogem/nehm)
 
 [![Build Status](https://travis-ci.org/spf13/cobra.svg "Travis CI status")](https://travis-ci.org/spf13/cobra)
 [![CircleCI status](https://circleci.com/gh/spf13/cobra.png?circle-token=:circle-token "CircleCI status")](https://circleci.com/gh/spf13/cobra)
-[![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra) 
+[![GoDoc](https://godoc.org/github.com/spf13/cobra?status.svg)](https://godoc.org/github.com/spf13/cobra)
 
-![cobra](https://cloud.githubusercontent.com/assets/173412/10911369/84832a8e-8212-11e5-9f82-cc96660a4794.gif)
+# Table of Contents
+
+- [Overview](#overview)
+- [Concepts](#concepts)
+  * [Commands](#commands)
+  * [Flags](#flags)
+- [Installing](#installing)
+- [Getting Started](#getting-started)
+  * [Using the Cobra Generator](#using-the-cobra-generator)
+  * [Using the Cobra Library](#using-the-cobra-library)
+  * [Working with Flags](#working-with-flags)
+  * [Positional and Custom Arguments](#positional-and-custom-arguments)
+  * [Example](#example)
+  * [Help Command](#help-command)
+  * [Usage Message](#usage-message)
+  * [PreRun and PostRun Hooks](#prerun-and-postrun-hooks)
+  * [Suggestions when "unknown command" happens](#suggestions-when-unknown-command-happens)
+  * [Generating documentation for your command](#generating-documentation-for-your-command)
+  * [Generating bash completions](#generating-bash-completions)
+- [Contributing](#contributing)
+- [License](#license)
 
 # Overview
 
@@ -39,26 +60,15 @@ Cobra provides:
 * Fully POSIX-compliant flags (including short & long versions)
 * Nested subcommands
 * Global, local and cascading flags
-* Easy generation of applications & commands with `cobra create appname` & `cobra add cmdname`
+* Easy generation of applications & commands with `cobra init appname` & `cobra add cmdname`
 * Intelligent suggestions (`app srver`... did you mean `app server`?)
 * Automatic help generation for commands and flags
-* Automatic detailed help for `app help [command]`
 * Automatic help flag recognition of `-h`, `--help`, etc.
 * Automatically generated bash autocomplete for your application
 * Automatically generated man pages for your application
 * Command aliases so you can change things without breaking them
-* The flexibilty to define your own help, usage, etc.
+* The flexibility to define your own help, usage, etc.
 * Optional tight integration with [viper](http://github.com/spf13/viper) for 12-factor apps
-
-Cobra has an exceptionally clean interface and simple design without needless
-constructors or initialization methods.
-
-Applications built with Cobra commands are designed to be as user-friendly as
-possible. Flags can be placed before or after the command (as long as a
-confusing space isn’t provided). Both short and long flags can be used. A
-command need not even be fully typed.  Help is automatically generated and
-available for the application or for a specific command using either the help
-command or the `--help` flag.
 
 # Concepts
 
@@ -78,11 +88,11 @@ A few good real world examples may better illustrate this point.
 
 In the following example, 'server' is a command, and 'port' is a flag:
 
-    > hugo server --port=1313
+    hugo server --port=1313
 
 In this command we are telling Git to clone the url bare.
 
-    > git clone URL --bare
+    git clone URL --bare
 
 ## Commands
 
@@ -92,20 +102,11 @@ have children commands and optionally run an action.
 
 In the example above, 'server' is the command.
 
-A Command has the following structure:
-
-```go
-type Command struct {
-    Use string // The one-line usage message.
-    Short string // The short description shown in the 'help' output.
-    Long string // The long message shown in the 'help <this-command>' output.
-    Run func(cmd *Command, args []string) // Run runs the command.
-}
-```
+[More about cobra.Command](https://godoc.org/github.com/spf13/cobra#Command)
 
 ## Flags
 
-A Flag is a way to modify the behavior of a command. Cobra supports
+A flag is a way to modify the behavior of a command. Cobra supports
 fully POSIX-compliant flags as well as the Go [flag package](https://golang.org/pkg/flag/).
 A Cobra command can define flags that persist through to children commands
 and flags that are only available to that command.
@@ -113,23 +114,15 @@ and flags that are only available to that command.
 In the example above, 'port' is the flag.
 
 Flag functionality is provided by the [pflag
-library](https://github.com/ogier/pflag), a fork of the flag standard library
+library](https://github.com/spf13/pflag), a fork of the flag standard library
 which maintains the same interface while adding POSIX compliance.
-
-## Usage
-
-Cobra works by creating a set of commands and then organizing them into a tree.
-The tree defines the structure of the application.
-
-Once each command is defined with its corresponding flags, then the
-tree is assigned to the commander which is finally executed.
 
 # Installing
 Using Cobra is easy. First, use `go get` to install the latest version
-of the library. This command will install the `cobra` generator executible
-along with the library:
+of the library. This command will install the `cobra` generator executable
+along with the library and its dependencies:
 
-    > go get -v github.com/spf13/cobra/cobra
+    go get -u github.com/spf13/cobra/cobra
 
 Next, include Cobra in your application:
 
@@ -139,8 +132,8 @@ import "github.com/spf13/cobra"
 
 # Getting Started
 
-While you are welcome to provide your own organization, typically a Cobra based
-application will follow the following organizational structure.
+While you are welcome to provide your own organization, typically a Cobra-based
+application will follow the following organizational structure:
 
 ```
   ▾ appName/
@@ -152,18 +145,23 @@ application will follow the following organizational structure.
       main.go
 ```
 
-In a Cobra app, typically the main.go file is very bare. It serves, one purpose, to initialize Cobra.
+In a Cobra app, typically the main.go file is very bare. It serves one purpose: initializing Cobra.
 
 ```go
 package main
 
-import "{pathToYourApp}/cmd"
+import (
+  "fmt"
+  "os"
+
+  "{pathToYourApp}/cmd"
+)
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+  if err := cmd.RootCmd.Execute(); err != nil {
+    fmt.Println(err)
+    os.Exit(1)
+  }
 }
 ```
 
@@ -172,99 +170,14 @@ func main() {
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-In order to use the cobra command, compile it using the following command:
+[Here](https://github.com/spf13/cobra/blob/master/cobra/README.md) you can find more information about it.
 
-    > go install github.com/spf13/cobra/cobra
+## Using the Cobra Library
 
-This will create the cobra executable under your go path bin directory!
-
-### cobra init
-
-The `cobra init [yourApp]` command will create your initial application code
-for you. It is a very powerful application that will populate your program with
-the right structure so you can immediately enjoy all the benefits of Cobra. It
-will also automatically apply the license you specify to your application.
-
-Cobra init is pretty smart. You can provide it a full path, or simply a path
-similar to what is expected in the import.
-
-```
-cobra init github.com/spf13/newAppName
-```
-
-### cobra add
-
-Once an application is initialized Cobra can create additional commands for you.
-Let's say you created an app and you wanted the following commands for it:
-
-* app serve
-* app config
-* app config create
-
-In your project directory (where your main.go file is) you would run the following:
-
-```
-cobra add serve
-cobra add config
-cobra add create -p 'configCmd'
-```
-
-Once you have run these three commands you would have an app structure that would look like:
-
-```
-  ▾ app/
-    ▾ cmd/
-        serve.go
-        config.go
-        create.go
-      main.go
-```
-
-at this point you can run `go run main.go` and it would run your app. `go run
-main.go serve`, `go run main.go config`, `go run main.go config create` along
-with `go run main.go help serve`, etc would all work.
-
-Obviously you haven't added your own code to these yet, the commands are ready
-for you to give them their tasks. Have fun.
-
-### Configuring the cobra generator
-
-The cobra generator will be easier to use if you provide a simple configuration
-file which will help you eliminate providing a bunch of repeated information in
-flags over and over.
-
-An example ~/.cobra.yaml file:
-
-```yaml
-author: Steve Francia <spf@spf13.com>
-license: MIT
-```
-
-You can specify no license by setting `license` to `none` or you can specify
-a custom license:
-
-```yaml
-license:
-  header: This file is part of {{ .appName }}.
-  text: |
-    {{ .copyright }}
-
-    This is my license. There are many like it, but this one is mine.
-    My license is my best friend. It is my life. I must master it as I must
-    master my life.  
-```
-
-## Manually implementing Cobra
-
-To manually implement cobra you need to create a bare main.go file and a RootCmd file.
+To manually implement Cobra you need to create a bare main.go file and a RootCmd file.
 You will optionally provide additional commands as you see fit.
 
-### Create the root command
-
-The root command represents your binary itself.
-
-
-#### Manually create rootCmd
+### Create rootCmd
 
 Cobra doesn't require any special constructors. Simply create your commands.
 
@@ -272,34 +185,71 @@ Ideally you place this in app/cmd/root.go:
 
 ```go
 var RootCmd = &cobra.Command{
-	Use:   "hugo",
-	Short: "Hugo is a very fast static site generator",
-	Long: `A Fast and Flexible Static Site Generator built with
+  Use:   "hugo",
+  Short: "Hugo is a very fast static site generator",
+  Long: `A Fast and Flexible Static Site Generator built with
                 love by spf13 and friends in Go.
                 Complete documentation is available at http://hugo.spf13.com`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// Do Stuff Here
-	},
+  Run: func(cmd *cobra.Command, args []string) {
+    // Do Stuff Here
+  },
 }
 ```
 
 You will additionally define flags and handle configuration in your init() function.
 
-for example cmd/root.go:
+For example cmd/root.go:
 
 ```go
+import (
+  "fmt"
+  "os"
+
+  homedir "github.com/mitchellh/go-homedir"
+  "github.com/spf13/cobra"
+  "github.com/spf13/viper"
+)
+
 func init() {
-	cobra.OnInitialize(initConfig)
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
-	RootCmd.PersistentFlags().StringVarP(&projectBase, "projectbase", "b", "", "base project directory eg. github.com/spf13/")
-	RootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "Author name for copyright attribution")
-	RootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "Name of license for the project (can provide `licensetext` in config)")
-	RootCmd.PersistentFlags().Bool("viper", true, "Use Viper for configuration")
-	viper.BindPFlag("author", RootCmd.PersistentFlags().Lookup("author"))
-	viper.BindPFlag("projectbase", RootCmd.PersistentFlags().Lookup("projectbase"))
-	viper.BindPFlag("useViper", RootCmd.PersistentFlags().Lookup("viper"))
-	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
-	viper.SetDefault("license", "apache")
+  cobra.OnInitialize(initConfig)
+  RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
+  RootCmd.PersistentFlags().StringVarP(&projectBase, "projectbase", "b", "", "base project directory eg. github.com/spf13/")
+  RootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "Author name for copyright attribution")
+  RootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "Name of license for the project (can provide `licensetext` in config)")
+  RootCmd.PersistentFlags().Bool("viper", true, "Use Viper for configuration")
+  viper.BindPFlag("author", RootCmd.PersistentFlags().Lookup("author"))
+  viper.BindPFlag("projectbase", RootCmd.PersistentFlags().Lookup("projectbase"))
+  viper.BindPFlag("useViper", RootCmd.PersistentFlags().Lookup("viper"))
+  viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")
+  viper.SetDefault("license", "apache")
+}
+
+func Execute() {
+  RootCmd.Execute()
+}
+
+func initConfig() {
+  // Don't forget to read config either from cfgFile or from home directory!
+  if cfgFile != "" {
+    // Use config file from the flag.
+    viper.SetConfigFile(cfgFile)
+  } else {
+    // Find home directory.
+    home, err := homedir.Dir()
+    if err != nil {
+      fmt.Println(err)
+      os.Exit(1)
+    }
+
+    // Search config in home directory with name ".cobra" (without extension).
+    viper.AddConfigPath(home)
+    viper.SetConfigName(".cobra")
+  }
+
+  if err := viper.ReadInConfig(); err != nil {
+    fmt.Println("Can't read config:", err)
+    os.Exit(1)
+  }
 }
 ```
 
@@ -313,16 +263,20 @@ In a Cobra app, typically the main.go file is very bare. It serves, one purpose,
 ```go
 package main
 
-import "{pathToYourApp}/cmd"
+import (
+  "fmt"
+  "os"
+
+  "{pathToYourApp}/cmd"
+)
 
 func main() {
-	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+  if err := cmd.RootCmd.Execute(); err != nil {
+    fmt.Println(err)
+    os.Exit(1)
+  }
 }
 ```
-
 
 ### Create additional commands
 
@@ -336,45 +290,22 @@ populate it with the following:
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+  "github.com/spf13/cobra"
+  "fmt"
 )
 
 func init() {
-	RootCmd.AddCommand(versionCmd)
+  RootCmd.AddCommand(versionCmd)
 }
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
-	},
+  Use:   "version",
+  Short: "Print the version number of Hugo",
+  Long:  `All software has versions. This is Hugo's`,
+  Run: func(cmd *cobra.Command, args []string) {
+    fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
+  },
 }
-```
-
-### Attach command to its parent
-
-
-If you notice in the above example we attach the command to its parent. In
-this case the parent is the rootCmd. In this example we are attaching it to the
-root, but commands can be attached at any level.
-
-```go
-RootCmd.AddCommand(versionCmd)
-```
-
-### Remove a command from its parent
-
-Removing a command is not a common action in simple programs, but it allows 3rd
-parties to customize an existing command tree.
-
-In this example, we remove the existing `VersionCmd` command of an existing
-root command, and we replace it with our own version:
-
-```go
-mainlib.RootCmd.RemoveCommand(mainlib.VersionCmd)
-mainlib.RootCmd.AddCommand(versionCmd)
 ```
 
 ## Working with Flags
@@ -412,6 +343,71 @@ A flag can also be assigned locally which will only apply to that specific comma
 RootCmd.Flags().StringVarP(&Source, "source", "s", "", "Source directory to read from")
 ```
 
+### Local Flag on Parent Commands
+
+By default Cobra only parses local flags on the target command, any local flags on 
+parent commands are ignored. By enabling `Command.TraverseChildren` Cobra will 
+parse local flags on each command before executing the target command.
+
+```go
+command := cobra.Command{
+  Use: "print [OPTIONS] [COMMANDS]",
+  TraverseChildren: true,
+}
+```
+
+### Bind Flags with Config
+
+You can also bind your flags with [viper](https://github.com/spf13/viper):
+```go
+var author string
+
+func init() {
+  RootCmd.PersistentFlags().StringVar(&author, "author", "YOUR NAME", "Author name for copyright attribution")
+  viper.BindPFlag("author", RootCmd.PersistentFlags().Lookup("author"))
+}
+```
+
+In this example the persistent flag `author` is bound with `viper`.
+**Note**, that the variable `author` will not be set to the value from config,
+when the `--author` flag is not provided by user.
+
+More in [viper documentation](https://github.com/spf13/viper#working-with-flags).
+
+## Positional and Custom Arguments
+
+Validation of positional arguments can be specified using the `Args` field
+of `Command`.
+
+The following validators are built in:
+
+- `NoArgs` - the command will report an error if there are any positional args.
+- `ArbitraryArgs` - the command will accept any args.
+- `OnlyValidArgs` - the command will report an error if there are any positional args that are not in the `ValidArgs` field of `Command`.
+- `MinimumNArgs(int)` - the command will report an error if there are not at least N positional args.
+- `MaximumNArgs(int)` - the command will report an error if there are more than N positional args.
+- `ExactArgs(int)` - the command will report an error if there are not exactly N positional args.
+- `RangeArgs(min, max)` - the command will report an error if the number of args is not between the minimum and maximum number of expected args.
+
+An example of setting the custom validator:
+
+```go
+var cmd = &cobra.Command{
+  Short: "hello",
+  Args: func(cmd *cobra.Command, args []string) error {
+    if len(args) < 1 {
+      return errors.New("requires at least one arg")
+    }
+    if myapp.IsValidColor(args[0]) {
+      return nil
+    }
+    return fmt.Errorf("invalid color specified: %s", args[0])
+  },
+  Run: func(cmd *cobra.Command, args []string) {
+    fmt.Println("Hello, World!")
+  },
+}
+```
 
 ## Example
 
@@ -428,62 +424,62 @@ More documentation about flags is available at https://github.com/spf13/pflag
 package main
 
 import (
-	"fmt"
-	"strings"
+  "fmt"
+  "strings"
 
-	"github.com/spf13/cobra"
+  "github.com/spf13/cobra"
 )
 
 func main() {
+  var echoTimes int
 
-	var echoTimes int
+  var cmdPrint = &cobra.Command{
+    Use:   "print [string to print]",
+    Short: "Print anything to the screen",
+    Long: `print is for printing anything back to the screen.
+For many years people have printed back to the screen.`,
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Println("Print: " + strings.Join(args, " "))
+    },
+  }
 
-	var cmdPrint = &cobra.Command{
-		Use:   "print [string to print]",
-		Short: "Print anything to the screen",
-		Long: `print is for printing anything back to the screen.
-            For many years people have printed back to the screen.
-            `,
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Print: " + strings.Join(args, " "))
-		},
-	}
+  var cmdEcho = &cobra.Command{
+    Use:   "echo [string to echo]",
+    Short: "Echo anything to the screen",
+    Long: `echo is for echoing anything back.
+Echo works a lot like print, except it has a child command.`,
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Println("Print: " + strings.Join(args, " "))
+    },
+  }
 
-	var cmdEcho = &cobra.Command{
-		Use:   "echo [string to echo]",
-		Short: "Echo anything to the screen",
-		Long: `echo is for echoing anything back.
-            Echo works a lot like print, except it has a child command.
-            `,
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Print: " + strings.Join(args, " "))
-		},
-	}
+  var cmdTimes = &cobra.Command{
+    Use:   "times [# times] [string to echo]",
+    Short: "Echo anything to the screen more times",
+    Long: `echo things multiple times back to the user by providing
+a count and a string.`,
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+      for i := 0; i < echoTimes; i++ {
+        fmt.Println("Echo: " + strings.Join(args, " "))
+      }
+    },
+  }
 
-	var cmdTimes = &cobra.Command{
-		Use:   "times [# times] [string to echo]",
-		Short: "Echo anything to the screen more times",
-		Long: `echo things multiple times back to the user by providing
-            a count and a string.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			for i := 0; i < echoTimes; i++ {
-				fmt.Println("Echo: " + strings.Join(args, " "))
-			}
-		},
-	}
+  cmdTimes.Flags().IntVarP(&echoTimes, "times", "t", 1, "times to echo the input")
 
-	cmdTimes.Flags().IntVarP(&echoTimes, "times", "t", 1, "times to echo the input")
-
-	var rootCmd = &cobra.Command{Use: "app"}
-	rootCmd.AddCommand(cmdPrint, cmdEcho)
-	cmdEcho.AddCommand(cmdTimes)
-	rootCmd.Execute()
+  var rootCmd = &cobra.Command{Use: "app"}
+  rootCmd.AddCommand(cmdPrint, cmdEcho)
+  cmdEcho.AddCommand(cmdTimes)
+  rootCmd.Execute()
 }
 ```
 
 For a more complete example of a larger application, please checkout [Hugo](http://gohugo.io/).
 
-## The Help Command
+## Help Command
 
 Cobra automatically adds a help command to your application when you have subcommands.
 This will be called when a user runs 'app help'. Additionally, help will also
@@ -496,60 +492,28 @@ create' is called.  Every command will automatically have the '--help' flag adde
 The following output is automatically generated by Cobra. Nothing beyond the
 command and flag definitions are needed.
 
-    > hugo help
+    $ cobra help
 
-    hugo is the main command, used to build your Hugo site.
-
-    Hugo is a Fast and Flexible Static Site Generator
-    built with love by spf13 and friends in Go.
-
-    Complete documentation is available at http://gohugo.io/.
+    Cobra is a CLI library for Go that empowers applications.
+    This application is a tool to generate the needed files
+    to quickly create a Cobra application.
 
     Usage:
-      hugo [flags]
-      hugo [command]
+      cobra [command]
 
     Available Commands:
-      server          Hugo runs its own webserver to render the files
-      version         Print the version number of Hugo
-      config          Print the site configuration
-      check           Check content in the source directory
-      benchmark       Benchmark hugo by building a site a number of times.
-      convert         Convert your content to different formats
-      new             Create new content for your site
-      list            Listing out various types of content
-      undraft         Undraft changes the content's draft status from 'True' to 'False'
-      genautocomplete Generate shell autocompletion script for Hugo
-      gendoc          Generate Markdown documentation for the Hugo CLI.
-      genman          Generate man page for Hugo
-      import          Import your site from others.
+      add         Add a command to a Cobra Application
+      help        Help about any command
+      init        Initialize a Cobra Application
 
     Flags:
-      -b, --baseURL="": hostname (and path) to the root, e.g. http://spf13.com/
-      -D, --buildDrafts[=false]: include content marked as draft
-      -F, --buildFuture[=false]: include content with publishdate in the future
-          --cacheDir="": filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
-          --canonifyURLs[=false]: if true, all relative URLs will be canonicalized using baseURL
-          --config="": config file (default is path/config.yaml|json|toml)
-      -d, --destination="": filesystem path to write files to
-          --disableRSS[=false]: Do not build RSS files
-          --disableSitemap[=false]: Do not build Sitemap file
-          --editor="": edit new content with this editor, if provided
-          --ignoreCache[=false]: Ignores the cache directory for reading but still writes to it
-          --log[=false]: Enable Logging
-          --logFile="": Log File path (if set, logging enabled automatically)
-          --noTimes[=false]: Don't sync modification time of files
-          --pluralizeListTitles[=true]: Pluralize titles in lists using inflect
-          --preserveTaxonomyNames[=false]: Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
-      -s, --source="": filesystem path to read files relative from
-          --stepAnalysis[=false]: display memory and timing of different steps of the program
-      -t, --theme="": theme to use (located in /themes/THEMENAME/)
-          --uglyURLs[=false]: if true, use /filename.html instead of /filename/
-      -v, --verbose[=false]: verbose output
-          --verboseLog[=false]: verbose logging
-      -w, --watch[=false]: watch filesystem for changes and recreate as needed
+      -a, --author string    author name for copyright attribution (default "YOUR NAME")
+          --config string    config file (default is $HOME/.cobra.yaml)
+      -h, --help             help for cobra
+      -l, --license string   name of license for the project
+          --viper            use Viper for configuration (default true)
 
-    Use "hugo [command] --help" for more information about a command.
+    Use "cobra [command] --help" for more information about a command.
 
 
 Help is just a command like any other. There is no special logic or behavior
@@ -557,38 +521,18 @@ around it. In fact, you can provide your own if you want.
 
 ### Defining your own help
 
-You can provide your own Help command or your own template for the default command to use.
-
-The default help command is
-
-```go
-func (c *Command) initHelp() {
-	if c.helpCommand == nil {
-		c.helpCommand = &Command{
-			Use:   "help [command]",
-			Short: "Help about any command",
-			Long: `Help provides help for any command in the application.
-        Simply type ` + c.Name() + ` help [path to command] for full details.`,
-			Run: c.HelpFunc(),
-		}
-	}
-	c.AddCommand(c.helpCommand)
-}
-```
-
-You can provide your own command, function or template through the following methods:
+You can provide your own Help command or your own template for the default command to use
+with followind functions:
 
 ```go
-command.SetHelpCommand(cmd *Command)
-
-command.SetHelpFunc(f func(*Command, []string))
-
-command.SetHelpTemplate(s string)
+cmd.SetHelpCommand(cmd *Command)
+cmd.SetHelpFunc(f func(*Command, []string))
+cmd.SetHelpTemplate(s string)
 ```
 
 The latter two will also apply to any children commands.
 
-## Usage
+## Usage Message
 
 When the user provides an invalid flag or invalid command, Cobra responds by
 showing the user the 'usage'.
@@ -597,73 +541,37 @@ showing the user the 'usage'.
 You may recognize this from the help above. That's because the default help
 embeds the usage as part of its output.
 
+    $ cobra --invalid
+    Error: unknown flag: --invalid
     Usage:
-      hugo [flags]
-      hugo [command]
+      cobra [command]
 
     Available Commands:
-      server          Hugo runs its own webserver to render the files
-      version         Print the version number of Hugo
-      config          Print the site configuration
-      check           Check content in the source directory
-      benchmark       Benchmark hugo by building a site a number of times.
-      convert         Convert your content to different formats
-      new             Create new content for your site
-      list            Listing out various types of content
-      undraft         Undraft changes the content's draft status from 'True' to 'False'
-      genautocomplete Generate shell autocompletion script for Hugo
-      gendoc          Generate Markdown documentation for the Hugo CLI.
-      genman          Generate man page for Hugo
-      import          Import your site from others.
+      add         Add a command to a Cobra Application
+      help        Help about any command
+      init        Initialize a Cobra Application
 
     Flags:
-      -b, --baseURL="": hostname (and path) to the root, e.g. http://spf13.com/
-      -D, --buildDrafts[=false]: include content marked as draft
-      -F, --buildFuture[=false]: include content with publishdate in the future
-          --cacheDir="": filesystem path to cache directory. Defaults: $TMPDIR/hugo_cache/
-          --canonifyURLs[=false]: if true, all relative URLs will be canonicalized using baseURL
-          --config="": config file (default is path/config.yaml|json|toml)
-      -d, --destination="": filesystem path to write files to
-          --disableRSS[=false]: Do not build RSS files
-          --disableSitemap[=false]: Do not build Sitemap file
-          --editor="": edit new content with this editor, if provided
-          --ignoreCache[=false]: Ignores the cache directory for reading but still writes to it
-          --log[=false]: Enable Logging
-          --logFile="": Log File path (if set, logging enabled automatically)
-          --noTimes[=false]: Don't sync modification time of files
-          --pluralizeListTitles[=true]: Pluralize titles in lists using inflect
-          --preserveTaxonomyNames[=false]: Preserve taxonomy names as written ("Gérard Depardieu" vs "gerard-depardieu")
-      -s, --source="": filesystem path to read files relative from
-          --stepAnalysis[=false]: display memory and timing of different steps of the program
-      -t, --theme="": theme to use (located in /themes/THEMENAME/)
-          --uglyURLs[=false]: if true, use /filename.html instead of /filename/
-      -v, --verbose[=false]: verbose output
-          --verboseLog[=false]: verbose logging
-      -w, --watch[=false]: watch filesystem for changes and recreate as needed
+      -a, --author string    author name for copyright attribution (default "YOUR NAME")
+          --config string    config file (default is $HOME/.cobra.yaml)
+      -h, --help             help for cobra
+      -l, --license string   name of license for the project
+          --viper            use Viper for configuration (default true)
+
+    Use "cobra [command] --help" for more information about a command.
 
 ### Defining your own usage
 You can provide your own usage function or template for Cobra to use.
-
-The default usage function is:
-
-```go
-return func(c *Command) error {
-	err := tmpl(c.Out(), c.UsageTemplate(), c)
-	return err
-}
-```
-
 Like help, the function and template are overridable through public methods:
 
 ```go
-command.SetUsageFunc(f func(*Command) error)
-
-command.SetUsageTemplate(s string)
+cmd.SetUsageFunc(f func(*Command) error)
+cmd.SetUsageTemplate(s string)
 ```
 
-## PreRun or PostRun Hooks
+## PreRun and PostRun Hooks
 
-It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  The `Persistent*Run` functions will be inherrited by children if they do not declare their own.  These function are run in the following order:
+It is possible to run functions before or after the main `Run` function of your command. The `PersistentPreRun` and `PreRun` functions will be executed before `Run`. `PersistentPostRun` and `PostRun` will be executed after `Run`.  The `Persistent*Run` functions will be inherited by children if they do not declare their own.  These functions are run in the following order:
 
 - `PersistentPreRun`
 - `PreRun`
@@ -677,105 +585,73 @@ An example of two commands which use all of these features is below.  When the s
 package main
 
 import (
-	"fmt"
+  "fmt"
 
-	"github.com/spf13/cobra"
+  "github.com/spf13/cobra"
 )
 
 func main() {
 
-	var rootCmd = &cobra.Command{
-		Use:   "root [sub]",
-		Short: "My root command",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
-		},
-		PreRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside rootCmd PreRun with args: %v\n", args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside rootCmd Run with args: %v\n", args)
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside rootCmd PostRun with args: %v\n", args)
-		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside rootCmd PersistentPostRun with args: %v\n", args)
-		},
-	}
+  var rootCmd = &cobra.Command{
+    Use:   "root [sub]",
+    Short: "My root command",
+    PersistentPreRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PersistentPreRun with args: %v\n", args)
+    },
+    PreRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PreRun with args: %v\n", args)
+    },
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd Run with args: %v\n", args)
+    },
+    PostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PostRun with args: %v\n", args)
+    },
+    PersistentPostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside rootCmd PersistentPostRun with args: %v\n", args)
+    },
+  }
 
-	var subCmd = &cobra.Command{
-		Use:   "sub [no options!]",
-		Short: "My subcommand",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside subCmd PreRun with args: %v\n", args)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside subCmd Run with args: %v\n", args)
-		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside subCmd PostRun with args: %v\n", args)
-		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Inside subCmd PersistentPostRun with args: %v\n", args)
-		},
-	}
+  var subCmd = &cobra.Command{
+    Use:   "sub [no options!]",
+    Short: "My subcommand",
+    PreRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside subCmd PreRun with args: %v\n", args)
+    },
+    Run: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside subCmd Run with args: %v\n", args)
+    },
+    PostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside subCmd PostRun with args: %v\n", args)
+    },
+    PersistentPostRun: func(cmd *cobra.Command, args []string) {
+      fmt.Printf("Inside subCmd PersistentPostRun with args: %v\n", args)
+    },
+  }
 
-	rootCmd.AddCommand(subCmd)
+  rootCmd.AddCommand(subCmd)
 
-	rootCmd.SetArgs([]string{""})
-	_ = rootCmd.Execute()
-	fmt.Print("\n")
-	rootCmd.SetArgs([]string{"sub", "arg1", "arg2"})
-	_ = rootCmd.Execute()
+  rootCmd.SetArgs([]string{""})
+  rootCmd.Execute()
+  fmt.Println()
+  rootCmd.SetArgs([]string{"sub", "arg1", "arg2"})
+  rootCmd.Execute()
 }
 ```
 
+Output:
+```
+Inside rootCmd PersistentPreRun with args: []
+Inside rootCmd PreRun with args: []
+Inside rootCmd Run with args: []
+Inside rootCmd PostRun with args: []
+Inside rootCmd PersistentPostRun with args: []
 
-## Alternative Error Handling
-
-Cobra also has functions where the return signature is an error. This allows for errors to bubble up to the top,
-providing a way to handle the errors in one location. The current list of functions that return an error is:
-
-* PersistentPreRunE
-* PreRunE
-* RunE
-* PostRunE
-* PersistentPostRunE
-
-If you would like to silence the default `error` and `usage` output in favor of your own, you can set `SilenceUsage`
-and `SilenceErrors` to `false` on the command. A child command respects these flags if they are set on the parent
-command.
-
-**Example Usage using RunE:**
-
-```go
-package main
-
-import (
-	"errors"
-	"log"
-
-	"github.com/spf13/cobra"
-)
-
-func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "hugo",
-		Short: "Hugo is a very fast static site generator",
-		Long: `A Fast and Flexible Static Site Generator built with
-                love by spf13 and friends in Go.
-                Complete documentation is available at http://hugo.spf13.com`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Do Stuff Here
-			return errors.New("some random error")
-		},
-	}
-
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
-	}
-}
+Inside rootCmd PersistentPreRun with args: [arg1 arg2]
+Inside subCmd PreRun with args: [arg1 arg2]
+Inside subCmd Run with args: [arg1 arg2]
+Inside subCmd PostRun with args: [arg1 arg2]
+Inside subCmd PersistentPostRun with args: [arg1 arg2]
 ```
 
 ## Suggestions when "unknown command" happens
@@ -818,81 +694,28 @@ Did you mean this?
 Run 'kubectl help' for usage.
 ```
 
-## Generating Markdown-formatted documentation for your command
+## Generating documentation for your command
 
-Cobra can generate a Markdown-formatted document based on the subcommands, flags, etc. A simple example of how to do this for your command can be found in [Markdown Docs](doc/md_docs.md).
+Cobra can generate documentation based on subcommands, flags, etc. in the following formats:
 
-## Generating man pages for your command
+- [Markdown](doc/md_docs.md)
+- [ReStructured Text](doc/rest_docs.md)
+- [Man Page](doc/man_docs.md)
 
-Cobra can generate a man page based on the subcommands, flags, etc. A simple example of how to do this for your command can be found in [Man Docs](doc/man_docs.md).
-
-## Generating bash completions for your command
+## Generating bash completions
 
 Cobra can generate a bash-completion file. If you add more information to your command, these completions can be amazingly powerful and flexible.  Read more about it in [Bash Completions](bash_completions.md).
 
-## Debugging
-
-Cobra provides a ‘DebugFlags’ method on a command which, when called, will print
-out everything Cobra knows about the flags for each command.
-
-### Example
-
-```go
-command.DebugFlags()
-```
-
-## Release Notes
-* **0.9.0** June 17, 2014
-  * flags can appears anywhere in the args (provided they are unambiguous)
-  * --help prints usage screen for app or command
-  * Prefix matching for commands
-  * Cleaner looking help and usage output
-  * Extensive test suite
-* **0.8.0** Nov 5, 2013
-  * Reworked interface to remove commander completely
-  * Command now primary structure
-  * No initialization needed
-  * Usage & Help templates & functions definable at any level
-  * Updated Readme
-* **0.7.0** Sept 24, 2013
-  * Needs more eyes
-  * Test suite
-  * Support for automatic error messages
-  * Support for help command
-  * Support for printing to any io.Writer instead of os.Stderr
-  * Support for persistent flags which cascade down tree
-  * Ready for integration into Hugo
-* **0.1.0** Sept 3, 2013
-  * Implement first draft
-
-## Extensions
-
-Libraries for extending Cobra:
-
-* [cmdns](https://github.com/gosuri/cmdns): Enables name spacing a command's immediate children. It provides an alternative way to structure subcommands, similar to `heroku apps:create` and `ovrclk clusters:launch`.
-
-## ToDo
-* Launch proper documentation site
-
-## Contributing
+# Contributing
 
 1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+2. Download your fork to your PC (`git clone https://github.com/your_username/cobra && cd cobra`)
+3. Create your feature branch (`git checkout -b my-new-feature`)
+4. Make changes and add them (`git add .`)
+5. Commit your changes (`git commit -m 'Add some feature'`)
+6. Push to the branch (`git push origin my-new-feature`)
+7. Create new pull request
 
-## Contributors
-
-Names in no particular order:
-
-* [spf13](https://github.com/spf13),
-[eparis](https://github.com/eparis),
-[bep](https://github.com/bep), and many more!
-
-## License
+# License
 
 Cobra is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/cobra/blob/master/LICENSE.txt)
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/spf13/cobra/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/vendor/github.com/spf13/cobra/args.go
+++ b/vendor/github.com/spf13/cobra/args.go
@@ -1,0 +1,98 @@
+package cobra
+
+import (
+	"fmt"
+)
+
+type PositionalArgs func(cmd *Command, args []string) error
+
+// Legacy arg validation has the following behaviour:
+// - root commands with no subcommands can take arbitrary arguments
+// - root commands with subcommands will do subcommand validity checking
+// - subcommands will always accept arbitrary arguments
+func legacyArgs(cmd *Command, args []string) error {
+	// no subcommand, always take args
+	if !cmd.HasSubCommands() {
+		return nil
+	}
+
+	// root command with subcommands, do subcommand checking
+	if !cmd.HasParent() && len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+	}
+	return nil
+}
+
+// NoArgs returns an error if any args are included
+func NoArgs(cmd *Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	}
+	return nil
+}
+
+// OnlyValidArgs returns an error if any args are not in the list of ValidArgs
+func OnlyValidArgs(cmd *Command, args []string) error {
+	if len(cmd.ValidArgs) > 0 {
+		for _, v := range args {
+			if !stringInSlice(v, cmd.ValidArgs) {
+				return fmt.Errorf("invalid argument %q for %q%s", v, cmd.CommandPath(), cmd.findSuggestions(args[0]))
+			}
+		}
+	}
+	return nil
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ArbitraryArgs never returns an error
+func ArbitraryArgs(cmd *Command, args []string) error {
+	return nil
+}
+
+// MinimumNArgs returns an error if there is not at least N args
+func MinimumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < n {
+			return fmt.Errorf("requires at least %d arg(s), only received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// MaximumNArgs returns an error if there are more than N args
+func MaximumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts at most %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// ExactArgs returns an error if there are not exactly n args
+func ExactArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("accepts %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// RangeArgs returns an error if the number of args is not within the expected range
+func RangeArgs(min int, max int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < min || len(args) > max {
+			return fmt.Errorf("accepts between %d and %d arg(s), received %d", min, max, len(args))
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/spf13/cobra/bash_completions.md
+++ b/vendor/github.com/spf13/cobra/bash_completions.md
@@ -18,7 +18,7 @@ func main() {
 }
 ```
 
-That will get you completions of subcommands and flags. If you make additional annotations to your code, you can get even more intelligent and flexible behavior.
+`out.sh` will get you completions of subcommands and flags. Copy it to `/etc/bash_completion.d/` as described [here](https://debian-administration.org/article/316/An_introduction_to_bash_completion_part_1) and reset your terminal to use autocompletion. If you make additional annotations to your code, you can get even more intelligent and flexible behavior.
 
 ## Creating your own custom functions
 
@@ -106,7 +106,7 @@ node                 pod                    replicationcontroller  service
 
 If your nouns have a number of aliases, you can define them alongside `ValidArgs` using `ArgAliases`:
 
-```go`
+```go
 argAliases []string = { "pods", "nodes", "services", "svc", "replicationcontrollers", "rc" }
 
 cmd := &cobra.Command{

--- a/vendor/github.com/spf13/cobra/cobra.go
+++ b/vendor/github.com/spf13/cobra/cobra.go
@@ -27,48 +27,59 @@ import (
 )
 
 var templateFuncs = template.FuncMap{
-	"trim":               strings.TrimSpace,
-	"trimRightSpace":     trimRightSpace,
-	"appendIfNotPresent": appendIfNotPresent,
-	"rpad":               rpad,
-	"gt":                 Gt,
-	"eq":                 Eq,
+	"trim":                    strings.TrimSpace,
+	"trimRightSpace":          trimRightSpace,
+	"trimTrailingWhitespaces": trimRightSpace,
+	"appendIfNotPresent":      appendIfNotPresent,
+	"rpad":                    rpad,
+	"gt":                      Gt,
+	"eq":                      Eq,
 }
 
 var initializers []func()
 
-// automatic prefix matching can be a dangerous thing to automatically enable in CLI tools.
-// Set this to true to enable it
+// EnablePrefixMatching allows to set automatic prefix matching. Automatic prefix matching can be a dangerous thing
+// to automatically enable in CLI tools.
+// Set this to true to enable it.
 var EnablePrefixMatching = false
 
-//EnableCommandSorting controls sorting of the slice of commands, which is turned on by default.
-//To disable sorting, set it to false.
+// EnableCommandSorting controls sorting of the slice of commands, which is turned on by default.
+// To disable sorting, set it to false.
 var EnableCommandSorting = true
 
-//AddTemplateFunc adds a template function that's available to Usage and Help
-//template generation.
+// MousetrapHelpText enables an information splash screen on Windows
+// if the CLI is started from explorer.exe.
+// To disable the mousetrap, just set this variable to blank string ("").
+// Works only on Microsoft Windows.
+var MousetrapHelpText string = `This is a command line tool.
+
+You need to open cmd.exe and run it from there.
+`
+
+// AddTemplateFunc adds a template function that's available to Usage and Help
+// template generation.
 func AddTemplateFunc(name string, tmplFunc interface{}) {
 	templateFuncs[name] = tmplFunc
 }
 
-//AddTemplateFuncs adds multiple template functions availalble to Usage and
-//Help template generation.
+// AddTemplateFuncs adds multiple template functions that are available to Usage and
+// Help template generation.
 func AddTemplateFuncs(tmplFuncs template.FuncMap) {
 	for k, v := range tmplFuncs {
 		templateFuncs[k] = v
 	}
 }
 
-//OnInitialize takes a series of func() arguments and appends them to a slice of func().
+// OnInitialize takes a series of func() arguments and appends them to a slice of func().
 func OnInitialize(y ...func()) {
-	for _, x := range y {
-		initializers = append(initializers, x)
-	}
+	initializers = append(initializers, y...)
 }
 
-//Gt takes two types and checks whether the first type is greater than the second. In case of types Arrays, Chans,
-//Maps and Slices, Gt will compare their lengths. Ints are compared directly while strings are first parsed as
-//ints and then compared.
+// FIXME Gt is unused by cobra and should be removed in a version 2. It exists only for compatibility with users of cobra.
+
+// Gt takes two types and checks whether the first type is greater than the second. In case of types Arrays, Chans,
+// Maps and Slices, Gt will compare their lengths. Ints are compared directly while strings are first parsed as
+// ints and then compared.
 func Gt(a interface{}, b interface{}) bool {
 	var left, right int64
 	av := reflect.ValueOf(a)
@@ -96,7 +107,9 @@ func Gt(a interface{}, b interface{}) bool {
 	return left > right
 }
 
-//Eq takes two types and checks whether they are equal. Supported types are int and string. Unsupported types will panic.
+// FIXME Eq is unused by cobra and should be removed in a version 2. It exists only for compatibility with users of cobra.
+
+// Eq takes two types and checks whether they are equal. Supported types are int and string. Unsupported types will panic.
 func Eq(a interface{}, b interface{}) bool {
 	av := reflect.ValueOf(a)
 	bv := reflect.ValueOf(b)
@@ -116,7 +129,9 @@ func trimRightSpace(s string) string {
 	return strings.TrimRightFunc(s, unicode.IsSpace)
 }
 
-// appendIfNotPresent will append stringToAppend to the end of s, but only if it's not yet present in s
+// FIXME appendIfNotPresent is unused by cobra and should be removed in a version 2. It exists only for compatibility with users of cobra.
+
+// appendIfNotPresent will append stringToAppend to the end of s, but only if it's not yet present in s.
 func appendIfNotPresent(s, stringToAppend string) string {
 	if strings.Contains(s, stringToAppend) {
 		return s
@@ -124,7 +139,7 @@ func appendIfNotPresent(s, stringToAppend string) string {
 	return s + " " + stringToAppend
 }
 
-//rpad adds padding to the right of a string
+// rpad adds padding to the right of a string.
 func rpad(s string, padding int) string {
 	template := fmt.Sprintf("%%-%ds", padding)
 	return fmt.Sprintf(template, s)
@@ -138,7 +153,7 @@ func tmpl(w io.Writer, text string, data interface{}) error {
 	return t.Execute(w, data)
 }
 
-// ld compares two strings and returns the levenshtein distance between them
+// ld compares two strings and returns the levenshtein distance between them.
 func ld(s, t string, ignoreCase bool) int {
 	if ignoreCase {
 		s = strings.ToLower(s)

--- a/vendor/github.com/spf13/cobra/cobra_test.go
+++ b/vendor/github.com/spf13/cobra/cobra_test.go
@@ -13,16 +13,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var _ = fmt.Println
-var _ = os.Stderr
-
-var tp, te, tt, t1, tr []string
+var tp, te, tt, tr []string
 var rootPersPre, echoPre, echoPersPre, timesPersPre []string
 var flagb1, flagb2, flagb3, flagbr, flagbp bool
 var flags1, flags2a, flags2b, flags3, outs string
 var flagi1, flagi2, flagi3, flagi4, flagir int
-var globalFlag1 bool
-var flagEcho, rootcalled bool
+var rootcalled bool
 var versionUsed int
 
 const strtwoParentHelp = "help message for parent flag strtwo"
@@ -40,6 +36,7 @@ var cmdHidden = &Command{
 
 var cmdPrint = &Command{
 	Use:   "print [string to print]",
+	Args:  MinimumNArgs(1),
 	Short: "Print anything to the screen",
 	Long:  `an absolutely utterly useless command for testing.`,
 	Run: func(cmd *Command, args []string) {
@@ -79,6 +76,7 @@ var cmdDeprecated = &Command{
 	Deprecated: "Please use echo instead",
 	Run: func(cmd *Command, args []string) {
 	},
+	Args: NoArgs,
 }
 
 var cmdTimes = &Command{
@@ -92,6 +90,8 @@ var cmdTimes = &Command{
 	Run: func(cmd *Command, args []string) {
 		tt = args
 	},
+	Args:      OnlyValidArgs,
+	ValidArgs: []string{"one", "two", "three", "four"},
 }
 
 var cmdRootNoRun = &Command{
@@ -107,6 +107,16 @@ var cmdRootSameName = &Command{
 	Use:   "print",
 	Short: "Root with the same name as a subcommand",
 	Long:  "The root description for help",
+}
+
+var cmdRootTakesArgs = &Command{
+	Use:   "root-with-args [random args]",
+	Short: "The root can run it's own function and takes args!",
+	Long:  "The root description for help, and some args",
+	Run: func(cmd *Command, args []string) {
+		tr = args
+	},
+	Args: ArbitraryArgs,
 }
 
 var cmdRootWithRun = &Command{
@@ -166,20 +176,23 @@ func flagInit() {
 	cmdRootWithRun.ResetFlags()
 	cmdSubNoRun.ResetFlags()
 	cmdCustomFlags.ResetFlags()
-	cmdRootNoRun.PersistentFlags().StringVarP(&flags2a, "strtwo", "t", "two", strtwoParentHelp)
-	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
-	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
-	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
-	cmdCustomFlags.Flags().IntVar(&flagi4, "intfour", 456, "help message for flag intfour")
-	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
-	cmdEcho.PersistentFlags().BoolVarP(&flagbp, "persistentbool", "p", false, "help message for flag persistentbool")
-	cmdTimes.PersistentFlags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
-	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
-	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
-	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
-	cmdPrint.Flags().BoolVarP(&flagb3, "boolthree", "b", true, "help message for flag boolthree")
 	cmdVersion1.ResetFlags()
 	cmdVersion2.ResetFlags()
+
+	cmdRootNoRun.PersistentFlags().StringVarP(&flags2a, "strtwo", "t", "two", strtwoParentHelp)
+	cmdCustomFlags.Flags().IntVar(&flagi4, "intfour", 456, "help message for flag intfour")
+	cmdEcho.Flags().BoolVarP(&flagb1, "boolone", "b", true, "help message for flag boolone")
+	cmdEcho.Flags().IntVarP(&flagi1, "intone", "i", 123, "help message for flag intone")
+	cmdEcho.PersistentFlags().BoolVarP(&flagbp, "persistentbool", "p", false, "help message for flag persistentbool")
+	cmdEcho.PersistentFlags().StringVarP(&flags1, "strone", "s", "one", "help message for flag strone")
+	cmdPrint.Flags().IntVarP(&flagi3, "intthree", "i", 345, "help message for flag intthree")
+	cmdTimes.Flags().BoolVarP(&flagb2, "booltwo", "c", false, "help message for flag booltwo")
+	cmdTimes.Flags().IntVarP(&flagi2, "inttwo", "j", 234, "help message for flag inttwo")
+	cmdTimes.Flags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
+	cmdTimes.PersistentFlags().StringVarP(&flags2b, "strtwo", "t", "2", strtwoChildHelp)
+	cmdTimes.LocalFlags() // populate lflags before parent is set
+	cmdPrint.Flags().BoolVarP(&flagb3, "boolthree", "b", true, "help message for flag boolthree")
+	cmdPrint.PersistentFlags().StringVarP(&flags3, "strthree", "s", "three", "help message for flag strthree")
 }
 
 func commandInit() {
@@ -198,8 +211,8 @@ func initialize() *Command {
 	rootPersPre, echoPre, echoPersPre, timesPersPre = nil, nil, nil, nil
 
 	var c = cmdRootNoRun
-	flagInit()
 	commandInit()
+	flagInit()
 	return c
 }
 
@@ -207,8 +220,8 @@ func initializeWithSameName() *Command {
 	tt, tp, te = nil, nil, nil
 	rootPersPre, echoPre, echoPersPre, timesPersPre = nil, nil, nil, nil
 	var c = cmdRootSameName
-	flagInit()
 	commandInit()
+	flagInit()
 	return c
 }
 
@@ -228,36 +241,36 @@ type resulter struct {
 	Command *Command
 }
 
-func fullSetupTest(input string) resulter {
+func fullSetupTest(args ...string) resulter {
 	c := initializeWithRootCmd()
 
-	return fullTester(c, input)
+	return fullTester(c, args...)
 }
 
-func noRRSetupTestSilenced(input string) resulter {
+func noRRSetupTestSilenced(args ...string) resulter {
 	c := initialize()
 	c.SilenceErrors = true
 	c.SilenceUsage = true
-	return fullTester(c, input)
+	return fullTester(c, args...)
 }
 
-func noRRSetupTest(input string) resulter {
+func noRRSetupTest(args ...string) resulter {
 	c := initialize()
 
-	return fullTester(c, input)
+	return fullTester(c, args...)
 }
 
-func rootOnlySetupTest(input string) resulter {
+func rootOnlySetupTest(args ...string) resulter {
 	c := initializeWithRootCmd()
 
-	return simpleTester(c, input)
+	return simpleTester(c, args...)
 }
 
-func simpleTester(c *Command, input string) resulter {
+func simpleTester(c *Command, args ...string) resulter {
 	buf := new(bytes.Buffer)
 	// Testing flag with invalid input
 	c.SetOutput(buf)
-	c.SetArgs(strings.Split(input, " "))
+	c.SetArgs(args)
 
 	err := c.Execute()
 	output := buf.String()
@@ -265,11 +278,11 @@ func simpleTester(c *Command, input string) resulter {
 	return resulter{err, output, c}
 }
 
-func simpleTesterC(c *Command, input string) resulter {
+func simpleTesterC(c *Command, args ...string) resulter {
 	buf := new(bytes.Buffer)
 	// Testing flag with invalid input
 	c.SetOutput(buf)
-	c.SetArgs(strings.Split(input, " "))
+	c.SetArgs(args)
 
 	cmd, err := c.ExecuteC()
 	output := buf.String()
@@ -277,13 +290,13 @@ func simpleTesterC(c *Command, input string) resulter {
 	return resulter{err, output, cmd}
 }
 
-func fullTester(c *Command, input string) resulter {
+func fullTester(c *Command, args ...string) resulter {
 	buf := new(bytes.Buffer)
 	// Testing flag with invalid input
 	c.SetOutput(buf)
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdPrint, cmdEcho, cmdSubNoRun, cmdCustomFlags, cmdDeprecated)
-	c.SetArgs(strings.Split(input, " "))
+	c.SetArgs(args)
 
 	err := c.Execute()
 	output := buf.String()
@@ -333,7 +346,7 @@ func checkOutputContains(t *testing.T, c *Command, check string) {
 }
 
 func TestSingleCommand(t *testing.T) {
-	noRRSetupTest("print one two")
+	noRRSetupTest("print", "one", "two")
 
 	if te != nil || tt != nil {
 		t.Error("Wrong command called")
@@ -347,7 +360,7 @@ func TestSingleCommand(t *testing.T) {
 }
 
 func TestChildCommand(t *testing.T) {
-	noRRSetupTest("echo times one two")
+	noRRSetupTest("echo", "times", "one", "two")
 
 	if te != nil || tp != nil {
 		t.Error("Wrong command called")
@@ -361,7 +374,7 @@ func TestChildCommand(t *testing.T) {
 }
 
 func TestCommandAlias(t *testing.T) {
-	noRRSetupTest("say times one two")
+	noRRSetupTest("say", "times", "one", "two")
 
 	if te != nil || tp != nil {
 		t.Error("Wrong command called")
@@ -376,7 +389,7 @@ func TestCommandAlias(t *testing.T) {
 
 func TestPrefixMatching(t *testing.T) {
 	EnablePrefixMatching = true
-	noRRSetupTest("ech times one two")
+	noRRSetupTest("ech", "times", "one", "two")
 
 	if te != nil || tp != nil {
 		t.Error("Wrong command called")
@@ -394,7 +407,7 @@ func TestPrefixMatching(t *testing.T) {
 func TestNoPrefixMatching(t *testing.T) {
 	EnablePrefixMatching = false
 
-	noRRSetupTest("ech times one two")
+	noRRSetupTest("ech", "times", "one", "two")
 
 	if !(tt == nil && te == nil && tp == nil) {
 		t.Error("Wrong command called")
@@ -403,7 +416,7 @@ func TestNoPrefixMatching(t *testing.T) {
 
 func TestAliasPrefixMatching(t *testing.T) {
 	EnablePrefixMatching = true
-	noRRSetupTest("sa times one two")
+	noRRSetupTest("sa", "times", "one", "two")
 
 	if te != nil || tp != nil {
 		t.Error("Wrong command called")
@@ -420,7 +433,7 @@ func TestAliasPrefixMatching(t *testing.T) {
 func TestChildSameName(t *testing.T) {
 	c := initializeWithSameName()
 	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(strings.Split("print one two", " "))
+	c.SetArgs([]string{"print", "one", "two"})
 	c.Execute()
 
 	if te != nil || tt != nil {
@@ -438,7 +451,7 @@ func TestGrandChildSameName(t *testing.T) {
 	c := initializeWithSameName()
 	cmdTimes.AddCommand(cmdPrint)
 	c.AddCommand(cmdTimes)
-	c.SetArgs(strings.Split("times print one two", " "))
+	c.SetArgs([]string{"times", "print", "one", "two"})
 	c.Execute()
 
 	if te != nil || tt != nil {
@@ -455,13 +468,70 @@ func TestGrandChildSameName(t *testing.T) {
 func TestUsage(t *testing.T) {
 	x := fullSetupTest("help")
 	checkResultContains(t, x, cmdRootWithRun.Use+" [flags]")
-	x = fullSetupTest("help customflags")
+	x = fullSetupTest("help", "customflags")
 	checkResultContains(t, x, cmdCustomFlags.Use)
 	checkResultOmits(t, x, cmdCustomFlags.Use+" [flags]")
 }
 
+func TestRootTakesNoArgs(t *testing.T) {
+	c := initializeWithSameName()
+	c.AddCommand(cmdPrint, cmdEcho)
+	result := simpleTester(c, "illegal")
+
+	if result.Error == nil {
+		t.Fatal("Expected an error")
+	}
+
+	expectedError := `unknown command "illegal" for "print"`
+	if !strings.Contains(result.Error.Error(), expectedError) {
+		t.Errorf("exptected %v, got %v", expectedError, result.Error.Error())
+	}
+}
+
+func TestRootTakesArgs(t *testing.T) {
+	c := cmdRootTakesArgs
+	result := simpleTester(c, "legal")
+
+	if result.Error != nil {
+		t.Errorf("expected no error, but got %v", result.Error)
+	}
+}
+
+func TestSubCmdTakesNoArgs(t *testing.T) {
+	result := fullSetupTest("deprecated", "illegal")
+
+	if result.Error == nil {
+		t.Fatal("Expected an error")
+	}
+
+	expectedError := `unknown command "illegal" for "cobra-test deprecated"`
+	if !strings.Contains(result.Error.Error(), expectedError) {
+		t.Errorf("expected %v, got %v", expectedError, result.Error.Error())
+	}
+}
+
+func TestSubCmdTakesArgs(t *testing.T) {
+	noRRSetupTest("echo", "times", "one", "two")
+	if strings.Join(tt, " ") != "one two" {
+		t.Error("Command didn't parse correctly")
+	}
+}
+
+func TestCmdOnlyValidArgs(t *testing.T) {
+	result := noRRSetupTest("echo", "times", "one", "two", "five")
+
+	if result.Error == nil {
+		t.Fatal("Expected an error")
+	}
+
+	expectedError := `invalid argument "five"`
+	if !strings.Contains(result.Error.Error(), expectedError) {
+		t.Errorf("expected %v, got %v", expectedError, result.Error.Error())
+	}
+}
+
 func TestFlagLong(t *testing.T) {
-	noRRSetupTest("echo --intone=13 something -- here")
+	noRRSetupTest("echo", "--intone=13", "something", "--", "here")
 
 	if cmdEcho.ArgsLenAtDash() != 1 {
 		t.Errorf("expected argsLenAtDash: %d but got %d", 1, cmdRootNoRun.ArgsLenAtDash())
@@ -478,7 +548,7 @@ func TestFlagLong(t *testing.T) {
 }
 
 func TestFlagShort(t *testing.T) {
-	noRRSetupTest("echo -i13 -- something here")
+	noRRSetupTest("echo", "-i13", "--", "something", "here")
 
 	if cmdEcho.ArgsLenAtDash() != 0 {
 		t.Errorf("expected argsLenAtDash: %d but got %d", 0, cmdRootNoRun.ArgsLenAtDash())
@@ -493,7 +563,7 @@ func TestFlagShort(t *testing.T) {
 		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
 	}
 
-	noRRSetupTest("echo -i 13 something here")
+	noRRSetupTest("echo", "-i", "13", "something", "here")
 
 	if strings.Join(te, " ") != "something here" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", te)
@@ -505,7 +575,7 @@ func TestFlagShort(t *testing.T) {
 		t.Errorf("default flag value changed, 234 expected, %d given", flagi2)
 	}
 
-	noRRSetupTest("print -i99 one two")
+	noRRSetupTest("print", "-i99", "one", "two")
 
 	if strings.Join(tp, " ") != "one two" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", tp)
@@ -519,14 +589,14 @@ func TestFlagShort(t *testing.T) {
 }
 
 func TestChildCommandFlags(t *testing.T) {
-	noRRSetupTest("echo times -j 99 one two")
+	noRRSetupTest("echo", "times", "-j", "99", "one", "two")
 
 	if strings.Join(tt, " ") != "one two" {
 		t.Errorf("flags didn't leave proper args remaining..%s given", tt)
 	}
 
 	// Testing with flag that shouldn't be persistent
-	r := noRRSetupTest("echo times -j 99 -i77 one two")
+	r := noRRSetupTest("echo", "times", "-j", "99", "-i77", "one", "two")
 
 	if r.Error == nil {
 		t.Errorf("invalid flag should generate error")
@@ -545,7 +615,7 @@ func TestChildCommandFlags(t *testing.T) {
 	}
 
 	// Testing with flag only existing on child
-	r = noRRSetupTest("echo -j 99 -i77 one two")
+	r = noRRSetupTest("echo", "-j", "99", "-i77", "one", "two")
 
 	if r.Error == nil {
 		t.Errorf("invalid flag should generate error")
@@ -555,7 +625,7 @@ func TestChildCommandFlags(t *testing.T) {
 	}
 
 	// Testing with persistent flag overwritten by child
-	noRRSetupTest("echo times --strtwo=child one two")
+	noRRSetupTest("echo", "times", "--strtwo=child", "one", "two")
 
 	if flags2b != "child" {
 		t.Errorf("flag value should be child, %s given", flags2b)
@@ -566,18 +636,18 @@ func TestChildCommandFlags(t *testing.T) {
 	}
 
 	// Testing flag with invalid input
-	r = noRRSetupTest("echo -i10E")
+	r = noRRSetupTest("echo", "-i10E")
 
 	if r.Error == nil {
 		t.Errorf("invalid input should generate error")
 	}
-	if !strings.Contains(r.Error.Error(), "invalid argument \"10E\" for i10E") {
+	if !strings.Contains(r.Error.Error(), "invalid syntax") {
 		t.Errorf("Wrong error message displayed, \n %s", r.Error)
 	}
 }
 
 func TestTrailingCommandFlags(t *testing.T) {
-	x := fullSetupTest("echo two -x")
+	x := fullSetupTest("echo", "two", "-x")
 
 	if x.Error == nil {
 		t.Errorf("invalid flag should generate error")
@@ -588,7 +658,7 @@ func TestInvalidSubcommandFlags(t *testing.T) {
 	cmd := initializeWithRootCmd()
 	cmd.AddCommand(cmdTimes)
 
-	result := simpleTester(cmd, "times --inttwo=2 --badflag=bar")
+	result := simpleTester(cmd, "times", "--inttwo=2", "--badflag=bar")
 	// given that we are not checking here result.Error we check for
 	// stock usage message
 	checkResultContains(t, result, "cobra-test times [# times]")
@@ -612,20 +682,20 @@ func TestSubcommandExecuteC(t *testing.T) {
 		Use: "echo message",
 		Run: func(c *Command, args []string) {
 			msg := strings.Join(args, " ")
-			c.Println(msg, msg)
+			c.Println(msg)
 		},
 	}
 
 	cmd.AddCommand(double, echo)
 
-	result := simpleTesterC(cmd, "double hello world")
+	result := simpleTesterC(cmd, "double", "hello", "world")
 	checkResultContains(t, result, "hello world hello world")
 
 	if result.Command.Name() != "double" {
 		t.Errorf("invalid cmd returned from ExecuteC: should be 'double' but got %s", result.Command.Name())
 	}
 
-	result = simpleTesterC(cmd, "echo msg to be echoed")
+	result = simpleTesterC(cmd, "echo", "msg", "to", "be", "echoed")
 	checkResultContains(t, result, "msg to be echoed")
 
 	if result.Command.Name() != "echo" {
@@ -651,16 +721,16 @@ func TestSubcommandArgEvaluation(t *testing.T) {
 	}
 	first.AddCommand(second)
 
-	result := simpleTester(cmd, "first second first third")
+	result := simpleTester(cmd, "first", "second", "first", "third")
 
-	expectedOutput := fmt.Sprintf("%v", []string{"first third"})
+	expectedOutput := fmt.Sprint([]string{"first third"})
 	if result.Output != expectedOutput {
 		t.Errorf("exptected %v, got %v", expectedOutput, result.Output)
 	}
 }
 
 func TestPersistentFlags(t *testing.T) {
-	fullSetupTest("echo -s something -p more here")
+	fullSetupTest("echo", "-s", "something", "-p", "more", "here")
 
 	// persistentFlag should act like normal flag on its own command
 	if strings.Join(te, " ") != "more here" {
@@ -674,10 +744,10 @@ func TestPersistentFlags(t *testing.T) {
 	}
 
 	// persistentFlag should act like normal flag on its own command
-	fullSetupTest("echo times -s again -c -p test here")
+	fullSetupTest("echo", "times", "-s", "again", "-c", "-p", "one", "two")
 
-	if strings.Join(tt, " ") != "test here" {
-		t.Errorf("flags didn't leave proper args remaining..%s given", tt)
+	if strings.Join(tt, " ") != "one two" {
+		t.Errorf("flags didn't leave proper args remaining. %s given", tt)
 	}
 
 	if flags1 != "again" {
@@ -696,17 +766,17 @@ func TestHelpCommand(t *testing.T) {
 	x := fullSetupTest("help")
 	checkResultContains(t, x, cmdRootWithRun.Long)
 
-	x = fullSetupTest("help echo")
+	x = fullSetupTest("help", "echo")
 	checkResultContains(t, x, cmdEcho.Long)
 
-	x = fullSetupTest("help echo times")
+	x = fullSetupTest("help", "echo", "times")
 	checkResultContains(t, x, cmdTimes.Long)
 }
 
 func TestChildCommandHelp(t *testing.T) {
-	c := noRRSetupTest("print --help")
+	c := noRRSetupTest("print", "--help")
 	checkResultContains(t, c, strtwoParentHelp)
-	r := noRRSetupTest("echo times --help")
+	r := noRRSetupTest("echo", "times", "--help")
 	checkResultContains(t, r, strtwoChildHelp)
 }
 
@@ -718,7 +788,7 @@ func TestNonRunChildHelp(t *testing.T) {
 func TestRunnableRootCommand(t *testing.T) {
 	x := fullSetupTest("")
 
-	if rootcalled != true {
+	if !rootcalled {
 		t.Errorf("Root Function was not called\n out:%v", x.Error)
 	}
 }
@@ -752,7 +822,6 @@ func TestVisitParents(t *testing.T) {
 }
 
 func TestRunnableRootCommandNilInput(t *testing.T) {
-	var emptyArg []string
 	c := initializeWithRootCmd()
 
 	buf := new(bytes.Buffer)
@@ -760,23 +829,20 @@ func TestRunnableRootCommandNilInput(t *testing.T) {
 	c.SetOutput(buf)
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(emptyArg)
+	c.SetArgs([]string{})
 
 	err := c.Execute()
 	if err != nil {
 		t.Errorf("Execute() failed with %v", err)
 	}
 
-	if rootcalled != true {
+	if !rootcalled {
 		t.Errorf("Root Function was not called")
 	}
 }
 
 func TestRunnableRootCommandEmptyInput(t *testing.T) {
-	args := make([]string, 3)
-	args[0] = ""
-	args[1] = "--introot=12"
-	args[2] = ""
+	args := []string{"", "--introot=12", ""}
 	c := initializeWithRootCmd()
 
 	buf := new(bytes.Buffer)
@@ -788,13 +854,13 @@ func TestRunnableRootCommandEmptyInput(t *testing.T) {
 
 	c.Execute()
 
-	if rootcalled != true {
-		t.Errorf("Root Function was not called.\n\nOutput was:\n\n%s\n", buf)
+	if !rootcalled {
+		t.Errorf("Root Function was not called.\nOutput was:\n%s\n", buf)
 	}
 }
 
 func TestInvalidSubcommandWhenArgsAllowed(t *testing.T) {
-	fullSetupTest("echo invalid-sub")
+	fullSetupTest("echo", "invalid-sub")
 
 	if te[0] != "invalid-sub" {
 		t.Errorf("Subcommand didn't work...")
@@ -802,9 +868,9 @@ func TestInvalidSubcommandWhenArgsAllowed(t *testing.T) {
 }
 
 func TestRootFlags(t *testing.T) {
-	fullSetupTest("-i 17 -b")
+	fullSetupTest("-i", "17", "-b")
 
-	if flagbr != true {
+	if !flagbr {
 		t.Errorf("flag value should be true, %v given", flagbr)
 	}
 
@@ -827,7 +893,7 @@ func TestRootHelp(t *testing.T) {
 		t.Errorf("--help shouldn't display subcommand's usage, Got: \n %s", x.Output)
 	}
 
-	x = fullSetupTest("echo --help")
+	x = fullSetupTest("echo", "--help")
 
 	if strings.Contains(x.Output, cmdTimes.Use) {
 		t.Errorf("--help shouldn't display subsubcommand's usage, Got: \n %s", x.Output)
@@ -845,6 +911,7 @@ func TestRootHelp(t *testing.T) {
 func TestFlagAccess(t *testing.T) {
 	initialize()
 
+	cmdEcho.AddCommand(cmdTimes)
 	local := cmdTimes.LocalFlags()
 	inherited := cmdTimes.InheritedFlags()
 
@@ -858,12 +925,10 @@ func TestFlagAccess(t *testing.T) {
 	}
 	if inherited.Lookup("strtwo") != nil {
 		t.Errorf("InheritedFlags shouldn not contain overwritten flag strtwo")
-
 	}
 }
 
 func TestNoNRunnableRootCommandNilInput(t *testing.T) {
-	var args []string
 	c := initialize()
 
 	buf := new(bytes.Buffer)
@@ -871,7 +936,7 @@ func TestNoNRunnableRootCommandNilInput(t *testing.T) {
 	c.SetOutput(buf)
 	cmdEcho.AddCommand(cmdTimes)
 	c.AddCommand(cmdPrint, cmdEcho)
-	c.SetArgs(args)
+	c.SetArgs([]string{})
 
 	c.Execute()
 
@@ -890,7 +955,7 @@ func TestRootNoCommandHelp(t *testing.T) {
 		t.Errorf("--help shouldn't trigger an error, Got: \n %s", x.Output)
 	}
 
-	x = rootOnlySetupTest("echo --help")
+	x = rootOnlySetupTest("echo", "--help")
 
 	checkResultOmits(t, x, "Available Commands:")
 	checkResultOmits(t, x, "for more information about a command")
@@ -908,7 +973,7 @@ func TestRootUnknownCommand(t *testing.T) {
 		t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", s, r.Output)
 	}
 
-	r = noRRSetupTest("--strtwo=a bogus")
+	r = noRRSetupTest("--strtwo=a", "bogus")
 	if r.Output != s {
 		t.Errorf("Unexpected response.\nExpecting to be:\n %q\nGot:\n %q\n", s, r.Output)
 	}
@@ -916,15 +981,14 @@ func TestRootUnknownCommand(t *testing.T) {
 
 func TestRootUnknownCommandSilenced(t *testing.T) {
 	r := noRRSetupTestSilenced("bogus")
-	s := "Run 'cobra-test --help' for usage.\n"
 
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be: \n\"\"\n Got:\n %q\n", r.Output)
 	}
 
-	r = noRRSetupTestSilenced("--strtwo=a bogus")
+	r = noRRSetupTestSilenced("--strtwo=a", "bogus")
 	if r.Output != "" {
-		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", s, r.Output)
+		t.Errorf("Unexpected response.\nExpecting to be:\n\"\"\nGot:\n %q\n", r.Output)
 	}
 }
 
@@ -969,56 +1033,27 @@ func TestRootSuggestions(t *testing.T) {
 
 func TestFlagsBeforeCommand(t *testing.T) {
 	// short without space
-	x := fullSetupTest("-i10 echo")
+	x := fullSetupTest("-i10", "echo")
 	if x.Error != nil {
 		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
 	}
 
-	// short (int) with equals
-	// It appears that pflags doesn't support this...
-	// Commenting out until support can be added
-
-	//x = noRRSetupTest("echo -i=10")
-	//if x.Error != nil {
-	//t.Errorf("Valid Input shouldn't have errors, got:\n %s", x.Error)
-	//}
+	x = noRRSetupTest("echo", "-i=10")
+	if x.Error != nil {
+		t.Errorf("Valid Input shouldn't have errors, got:\n %s", x.Error)
+	}
 
 	// long with equals
-	x = noRRSetupTest("--intone=123 echo one two")
+	x = noRRSetupTest("--intone=123", "echo", "one", "two")
 	if x.Error != nil {
 		t.Errorf("Valid Input shouldn't have errors, got:\n %s", x.Error)
 	}
 
 	// With parsing error properly reported
-	x = fullSetupTest("-i10E echo")
-	if !strings.Contains(x.Error.Error(), "invalid argument \"10E\" for i10E") {
+	x = fullSetupTest("-i10E", "echo")
+	if !strings.Contains(x.Error.Error(), "invalid syntax") {
 		t.Errorf("Wrong error message displayed, \n %s", x.Error)
 	}
-
-	//With quotes
-	x = fullSetupTest("-s=\"walking\" echo")
-	if x.Error != nil {
-		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
-	}
-
-	//With quotes and space
-	x = fullSetupTest("-s=\"walking fast\" echo")
-	if x.Error != nil {
-		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
-	}
-
-	//With inner quote
-	x = fullSetupTest("-s=\"walking \\\"Inner Quote\\\" fast\" echo")
-	if x.Error != nil {
-		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
-	}
-
-	//With quotes and space
-	x = fullSetupTest("-s=\"walking \\\"Inner Quote\\\" fast\" echo")
-	if x.Error != nil {
-		t.Errorf("Valid Input shouldn't have errors, got:\n %q", x.Error)
-	}
-
 }
 
 func TestRemoveCommand(t *testing.T) {
@@ -1084,7 +1119,7 @@ func TestDeprecatedSub(t *testing.T) {
 }
 
 func TestPreRun(t *testing.T) {
-	noRRSetupTest("echo one two")
+	noRRSetupTest("echo", "one", "two")
 	if echoPre == nil || echoPersPre == nil {
 		t.Error("PreRun or PersistentPreRun not called")
 	}
@@ -1092,7 +1127,7 @@ func TestPreRun(t *testing.T) {
 		t.Error("Wrong *Pre functions called!")
 	}
 
-	noRRSetupTest("echo times one two")
+	noRRSetupTest("echo", "times", "one", "two")
 	if timesPersPre == nil {
 		t.Error("PreRun or PersistentPreRun not called")
 	}
@@ -1100,7 +1135,7 @@ func TestPreRun(t *testing.T) {
 		t.Error("Wrong *Pre functions called!")
 	}
 
-	noRRSetupTest("print one two")
+	noRRSetupTest("print", "one", "two")
 	if rootPersPre == nil {
 		t.Error("Parent PersistentPreRun not called but should not have been")
 	}
@@ -1118,10 +1153,10 @@ func TestPeristentPreRunPropagation(t *testing.T) {
 	// Now add cmdPrint to rootCmd
 	rootCmd.AddCommand(cmdPrint)
 
-	rootCmd.SetArgs(strings.Split("print echosub lala", " "))
+	rootCmd.SetArgs([]string{"print", "echosub", "lala"})
 	rootCmd.Execute()
 
-	if rootPersPre == nil || len(rootPersPre) == 0 || rootPersPre[0] != "lala" {
+	if len(rootPersPre) == 0 || rootPersPre[0] != "lala" {
 		t.Error("RootCmd PersistentPreRun not called but should have been")
 	}
 }
@@ -1132,9 +1167,16 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 	}
 
 	rootCmd := initialize()
+	rootCmd.AddCommand(cmdEcho)
+
 	rootCmd.SetGlobalNormalizationFunc(normFunc)
-	if reflect.ValueOf(normFunc) != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()) {
+	if reflect.ValueOf(normFunc).Pointer() != reflect.ValueOf(rootCmd.GlobalNormalizationFunc()).Pointer() {
 		t.Error("rootCmd seems to have a wrong normalization function")
+	}
+
+	// Also check it propagates retroactively
+	if reflect.ValueOf(normFunc).Pointer() != reflect.ValueOf(cmdEcho.GlobalNormalizationFunc()).Pointer() {
+		t.Error("cmdEcho should have had the normalization function of rootCmd")
 	}
 
 	// First add the cmdEchoSub to cmdPrint
@@ -1151,12 +1193,76 @@ func TestGlobalNormFuncPropagation(t *testing.T) {
 	}
 }
 
+func TestNormPassedOnLocal(t *testing.T) {
+	n := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(strings.ToUpper(name))
+	}
+
+	cmd := &Command{}
+	flagVal := false
+
+	cmd.Flags().BoolVar(&flagVal, "flagname", true, "this is a dummy flag")
+	cmd.SetGlobalNormalizationFunc(n)
+	if cmd.LocalFlags().Lookup("flagname") != cmd.LocalFlags().Lookup("FLAGNAME") {
+		t.Error("Normalization function should be passed on to Local flag set")
+	}
+}
+
+func TestNormPassedOnInherited(t *testing.T) {
+	n := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(strings.ToUpper(name))
+	}
+
+	cmd, childBefore, childAfter := &Command{}, &Command{}, &Command{}
+	flagVal := false
+	cmd.AddCommand(childBefore)
+
+	cmd.PersistentFlags().BoolVar(&flagVal, "flagname", true, "this is a dummy flag")
+	cmd.SetGlobalNormalizationFunc(n)
+
+	cmd.AddCommand(childAfter)
+
+	if f := childBefore.InheritedFlags(); f.Lookup("flagname") == nil || f.Lookup("flagname") != f.Lookup("FLAGNAME") {
+		t.Error("Normalization function should be passed on to inherited flag set in command added before flag")
+	}
+	if f := childAfter.InheritedFlags(); f.Lookup("flagname") == nil || f.Lookup("flagname") != f.Lookup("FLAGNAME") {
+		t.Error("Normalization function should be passed on to inherited flag set in command added after flag")
+	}
+}
+
+// Related to https://github.com/spf13/cobra/issues/521.
+func TestNormConsistent(t *testing.T) {
+	n := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(strings.ToUpper(name))
+	}
+	id := func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		return pflag.NormalizedName(name)
+	}
+
+	cmd := &Command{}
+	flagVal := false
+
+	cmd.Flags().BoolVar(&flagVal, "flagname", true, "this is a dummy flag")
+	// Build local flag set
+	cmd.LocalFlags()
+
+	cmd.SetGlobalNormalizationFunc(n)
+	cmd.SetGlobalNormalizationFunc(id)
+
+	if cmd.LocalFlags().Lookup("flagname") == cmd.LocalFlags().Lookup("FLAGNAME") {
+		t.Error("Normalizing flag names should not result in duplicate flags")
+	}
+}
+
 func TestFlagOnPflagCommandLine(t *testing.T) {
 	flagName := "flagOnCommandLine"
-	pflag.CommandLine.String(flagName, "", "about my flag")
+	pflag.String(flagName, "", "about my flag")
 	r := fullSetupTest("--help")
 
 	checkResultContains(t, r, flagName)
+
+	// Reset pflag.CommandLine flagset.
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 }
 
 func TestAddTemplateFunctions(t *testing.T) {
@@ -1184,5 +1290,25 @@ func TestUsageIsNotPrintedTwice(t *testing.T) {
 	r := simpleTester(cmd, "")
 	if strings.Count(r.Output, "Usage:") != 1 {
 		t.Error("Usage output is not printed exactly once")
+	}
+}
+
+func BenchmarkInheritedFlags(b *testing.B) {
+	initialize()
+	cmdEcho.AddCommand(cmdTimes)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmdTimes.InheritedFlags()
+	}
+}
+
+func BenchmarkLocalFlags(b *testing.B) {
+	initialize()
+	cmdEcho.AddCommand(cmdTimes)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmdTimes.LocalFlags()
 	}
 }

--- a/vendor/github.com/spf13/cobra/command.go
+++ b/vendor/github.com/spf13/cobra/command.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//Package cobra is a commander providing a simple interface to create powerful modern CLI interfaces.
-//In addition to providing an interface, Cobra simultaneously provides a controller to organize your application code.
+// Package cobra is a commander providing a simple interface to create powerful modern CLI interfaces.
+// In addition to providing an interface, Cobra simultaneously provides a controller to organize your application code.
 package cobra
 
 import (
@@ -28,107 +28,154 @@ import (
 )
 
 // Command is just that, a command for your application.
-// eg.  'go run' ... 'run' is the command. Cobra requires
+// E.g.  'go run ...' - 'run' is the command. Cobra requires
 // you to define the usage and description as part of your command
 // definition to ensure usability.
 type Command struct {
-	// Name is the command name, usually the executable's name.
-	name string
-	// The one-line usage message.
+	// Use is the one-line usage message.
 	Use string
-	// An array of aliases that can be used instead of the first word in Use.
+
+	// Aliases is an array of aliases that can be used instead of the first word in Use.
 	Aliases []string
-	// An array of command names for which this command will be suggested - similar to aliases but only suggests.
+
+	// SuggestFor is an array of command names for which this command will be suggested -
+	// similar to aliases but only suggests.
 	SuggestFor []string
-	// The short description shown in the 'help' output.
+
+	// Short is the short description shown in the 'help' output.
 	Short string
-	// The long message shown in the 'help <this-command>' output.
+
+	// Long is the long message shown in the 'help <this-command>' output.
 	Long string
-	// Examples of how to use the command
+
+	// Example is examples of how to use the command.
 	Example string
-	// List of all valid non-flag arguments that are accepted in bash completions
+
+	// ValidArgs is list of all valid non-flag arguments that are accepted in bash completions
 	ValidArgs []string
-	// List of aliases for ValidArgs. These are not suggested to the user in the bash
-	// completion, but accepted if entered manually.
+
+	// Expected arguments
+	Args PositionalArgs
+
+	// ArgAliases is List of aliases for ValidArgs.
+	// These are not suggested to the user in the bash completion,
+	// but accepted if entered manually.
 	ArgAliases []string
-	// Custom functions used by the bash autocompletion generator
+
+	// BashCompletionFunction is custom functions used by the bash autocompletion generator.
 	BashCompletionFunction string
-	// Is this command deprecated and should print this string when used?
+
+	// Deprecated defines, if this command is deprecated and should print this string when used.
 	Deprecated string
-	// Is this command hidden and should NOT show up in the list of available commands?
+
+	// Hidden defines, if this command is hidden and should NOT show up in the list of available commands.
 	Hidden bool
-	// Full set of flags
-	flags *flag.FlagSet
-	// Set of flags childrens of this command will inherit
-	pflags *flag.FlagSet
-	// Flags that are declared specifically by this command (not inherited).
-	lflags *flag.FlagSet
-	// SilenceErrors is an option to quiet errors down stream
-	SilenceErrors bool
-	// Silence Usage is an option to silence usage when an error occurs.
-	SilenceUsage bool
+
+	// Annotations are key/value pairs that can be used by applications to identify or
+	// group commands.
+	Annotations map[string]string
+
 	// The *Run functions are executed in the following order:
 	//   * PersistentPreRun()
 	//   * PreRun()
 	//   * Run()
 	//   * PostRun()
 	//   * PersistentPostRun()
-	// All functions get the same args, the arguments after the command name
-	// PersistentPreRun: children of this command will inherit and execute
+	// All functions get the same args, the arguments after the command name.
+	//
+	// PersistentPreRun: children of this command will inherit and execute.
 	PersistentPreRun func(cmd *Command, args []string)
-	// PersistentPreRunE: PersistentPreRun but returns an error
+	// PersistentPreRunE: PersistentPreRun but returns an error.
 	PersistentPreRunE func(cmd *Command, args []string) error
 	// PreRun: children of this command will not inherit.
 	PreRun func(cmd *Command, args []string)
-	// PreRunE: PreRun but returns an error
+	// PreRunE: PreRun but returns an error.
 	PreRunE func(cmd *Command, args []string) error
-	// Run: Typically the actual work function. Most commands will only implement this
+	// Run: Typically the actual work function. Most commands will only implement this.
 	Run func(cmd *Command, args []string)
-	// RunE: Run but returns an error
+	// RunE: Run but returns an error.
 	RunE func(cmd *Command, args []string) error
 	// PostRun: run after the Run command.
 	PostRun func(cmd *Command, args []string)
-	// PostRunE: PostRun but returns an error
+	// PostRunE: PostRun but returns an error.
 	PostRunE func(cmd *Command, args []string) error
-	// PersistentPostRun: children of this command will inherit and execute after PostRun
+	// PersistentPostRun: children of this command will inherit and execute after PostRun.
 	PersistentPostRun func(cmd *Command, args []string)
-	// PersistentPostRunE: PersistentPostRun but returns an error
+	// PersistentPostRunE: PersistentPostRun but returns an error.
 	PersistentPostRunE func(cmd *Command, args []string) error
-	// DisableAutoGenTag remove
+
+	// SilenceErrors is an option to quiet errors down stream.
+	SilenceErrors bool
+
+	// SilenceUsage is an option to silence usage when an error occurs.
+	SilenceUsage bool
+
+	// DisableFlagParsing disables the flag parsing.
+	// If this is true all flags will be passed to the command as arguments.
+	DisableFlagParsing bool
+
+	// DisableAutoGenTag defines, if gen tag ("Auto generated by spf13/cobra...")
+	// will be printed by generating docs for this command.
 	DisableAutoGenTag bool
-	// Commands is the list of commands supported by this program.
+
+	// DisableSuggestions disables the suggestions based on Levenshtein distance
+	// that go along with 'unknown command' messages.
+	DisableSuggestions bool
+	// SuggestionsMinimumDistance defines minimum levenshtein distance to display suggestions.
+	// Must be > 0.
+	SuggestionsMinimumDistance int
+
+	// TraverseChildren parses flags on all parents before executing child command.
+	TraverseChildren bool
+
+	// commands is the list of commands supported by this program.
 	commands []*Command
-	// Parent Command for this command
+	// parent is a parent command for this command.
 	parent *Command
-	// max lengths of commands' string lengths for use in padding
+	// Max lengths of commands' string lengths for use in padding.
 	commandsMaxUseLen         int
 	commandsMaxCommandPathLen int
 	commandsMaxNameLen        int
-	// is commands slice are sorted or not
+	// commandsAreSorted defines, if command slice are sorted or not.
 	commandsAreSorted bool
 
+	// args is actual args parsed from flags.
+	args []string
+	// flagErrorBuf contains all error messages from pflag.
 	flagErrorBuf *bytes.Buffer
-
-	args          []string                 // actual args parsed from flags
-	output        *io.Writer               // out writer if set in SetOutput(w)
-	usageFunc     func(*Command) error     // Usage can be defined by application
-	usageTemplate string                   // Can be defined by Application
-	helpTemplate  string                   // Can be defined by Application
-	helpFunc      func(*Command, []string) // Help can be defined by application
-	helpCommand   *Command                 // The help command
-	// The global normalization function that we can use on every pFlag set and children commands
+	// flags is full set of flags.
+	flags *flag.FlagSet
+	// pflags contains persistent flags.
+	pflags *flag.FlagSet
+	// lflags contains local flags.
+	lflags *flag.FlagSet
+	// iflags contains inherited flags.
+	iflags *flag.FlagSet
+	// parentsPflags is all persistent flags of cmd's parents.
+	parentsPflags *flag.FlagSet
+	// globNormFunc is the global normalization function
+	// that we can use on every pflag set and children commands
 	globNormFunc func(f *flag.FlagSet, name string) flag.NormalizedName
 
-	// Disable the suggestions based on Levenshtein distance that go along with 'unknown command' messages
-	DisableSuggestions bool
-	// If displaying suggestions, allows to set the minimum levenshtein distance to display, must be > 0
-	SuggestionsMinimumDistance int
-
-	// Disable the flag parsing. If this is true all flags will be passed to the command as arguments.
-	DisableFlagParsing bool
+	// output is an output writer defined by user.
+	output io.Writer
+	// usageFunc is usage func defined by user.
+	usageFunc func(*Command) error
+	// usageTemplate is usage template defined by user.
+	usageTemplate string
+	// flagErrorFunc is func defined by user and it's called when the parsing of
+	// flags returns an error.
+	flagErrorFunc func(*Command, error) error
+	// helpTemplate is help template defined by user.
+	helpTemplate string
+	// helpFunc is help func defined by user.
+	helpFunc func(*Command, []string)
+	// helpCommand is command with usage 'help'. If it's not defined by user,
+	// cobra uses default help command.
+	helpCommand *Command
 }
 
-// os.Args[1:] by default, if desired, can be overridden
+// SetArgs sets arguments for the command. It is set to os.Args[1:] by default, if desired, can be overridden
 // particularly useful when testing.
 func (c *Command) SetArgs(a []string) {
 	c.args = a
@@ -137,29 +184,36 @@ func (c *Command) SetArgs(a []string) {
 // SetOutput sets the destination for usage and error messages.
 // If output is nil, os.Stderr is used.
 func (c *Command) SetOutput(output io.Writer) {
-	c.output = &output
+	c.output = output
 }
 
-// Usage can be defined by application
+// SetUsageFunc sets usage function. Usage can be defined by application.
 func (c *Command) SetUsageFunc(f func(*Command) error) {
 	c.usageFunc = f
 }
 
-// Can be defined by Application
+// SetUsageTemplate sets usage template. Can be defined by Application.
 func (c *Command) SetUsageTemplate(s string) {
 	c.usageTemplate = s
 }
 
-// Can be defined by Application
+// SetFlagErrorFunc sets a function to generate an error when flag parsing
+// fails.
+func (c *Command) SetFlagErrorFunc(f func(*Command, error) error) {
+	c.flagErrorFunc = f
+}
+
+// SetHelpFunc sets help function. Can be defined by Application.
 func (c *Command) SetHelpFunc(f func(*Command, []string)) {
 	c.helpFunc = f
 }
 
+// SetHelpCommand sets help command.
 func (c *Command) SetHelpCommand(cmd *Command) {
 	c.helpCommand = cmd
 }
 
-// Can be defined by Application
+// SetHelpTemplate sets help template to be used. Application can use it to set custom template.
 func (c *Command) SetHelpTemplate(s string) {
 	c.helpTemplate = s
 }
@@ -176,17 +230,19 @@ func (c *Command) SetGlobalNormalizationFunc(n func(f *flag.FlagSet, name string
 	}
 }
 
+// OutOrStdout returns output to stdout.
 func (c *Command) OutOrStdout() io.Writer {
 	return c.getOut(os.Stdout)
 }
 
+// OutOrStderr returns output to stderr
 func (c *Command) OutOrStderr() io.Writer {
 	return c.getOut(os.Stderr)
 }
 
 func (c *Command) getOut(def io.Writer) io.Writer {
 	if c.output != nil {
-		return *c.output
+		return c.output
 	}
 	if c.HasParent() {
 		return c.parent.getOut(def)
@@ -195,14 +251,13 @@ func (c *Command) getOut(def io.Writer) io.Writer {
 }
 
 // UsageFunc returns either the function set by SetUsageFunc for this command
-// or a parent, or it returns a default usage function
+// or a parent, or it returns a default usage function.
 func (c *Command) UsageFunc() (f func(*Command) error) {
 	if c.usageFunc != nil {
 		return c.usageFunc
 	}
-
 	if c.HasParent() {
-		return c.parent.UsageFunc()
+		return c.Parent().UsageFunc()
 	}
 	return func(c *Command) error {
 		c.mergePersistentFlags()
@@ -214,24 +269,23 @@ func (c *Command) UsageFunc() (f func(*Command) error) {
 	}
 }
 
-// Output the usage for the command
-// Used when a user provides invalid input
-// Can be defined by user by overriding UsageFunc
+// Usage puts out the usage for the command.
+// Used when a user provides invalid input.
+// Can be defined by user by overriding UsageFunc.
 func (c *Command) Usage() error {
 	return c.UsageFunc()(c)
 }
 
 // HelpFunc returns either the function set by SetHelpFunc for this command
-// or a parent, or it returns a function with default help behavior
+// or a parent, or it returns a function with default help behavior.
 func (c *Command) HelpFunc() func(*Command, []string) {
-	cmd := c
-	for cmd != nil {
-		if cmd.helpFunc != nil {
-			return cmd.helpFunc
-		}
-		cmd = cmd.parent
+	if c.helpFunc != nil {
+		return c.helpFunc
 	}
-	return func(*Command, []string) {
+	if c.HasParent() {
+		return c.Parent().HelpFunc()
+	}
+	return func(c *Command, a []string) {
 		c.mergePersistentFlags()
 		err := tmpl(c.OutOrStdout(), c.HelpTemplate(), c)
 		if err != nil {
@@ -240,14 +294,15 @@ func (c *Command) HelpFunc() func(*Command, []string) {
 	}
 }
 
-// Output the help for the command
-// Used when a user calls help [command]
-// Can be defined by user by overriding HelpFunc
+// Help puts out the help for the command.
+// Used when a user calls help [command].
+// Can be defined by user by overriding HelpFunc.
 func (c *Command) Help() error {
 	c.HelpFunc()(c, []string{})
 	return nil
 }
 
+// UsageString return usage string.
 func (c *Command) UsageString() string {
 	tmpOutput := c.output
 	bb := new(bytes.Buffer)
@@ -257,8 +312,25 @@ func (c *Command) UsageString() string {
 	return bb.String()
 }
 
+// FlagErrorFunc returns either the function set by SetFlagErrorFunc for this
+// command or a parent, or it returns a function which returns the original
+// error.
+func (c *Command) FlagErrorFunc() (f func(*Command, error) error) {
+	if c.flagErrorFunc != nil {
+		return c.flagErrorFunc
+	}
+
+	if c.HasParent() {
+		return c.parent.FlagErrorFunc()
+	}
+	return func(c *Command, err error) error {
+		return err
+	}
+}
+
 var minUsagePadding = 25
 
+// UsagePadding return padding for the usage.
 func (c *Command) UsagePadding() int {
 	if c.parent == nil || minUsagePadding > c.parent.commandsMaxUseLen {
 		return minUsagePadding
@@ -268,7 +340,7 @@ func (c *Command) UsagePadding() int {
 
 var minCommandPathPadding = 11
 
-//
+// CommandPathPadding return padding for the command path.
 func (c *Command) CommandPathPadding() int {
 	if c.parent == nil || minCommandPathPadding > c.parent.commandsMaxCommandPathLen {
 		return minCommandPathPadding
@@ -278,6 +350,7 @@ func (c *Command) CommandPathPadding() int {
 
 var minNamePadding = 11
 
+// NamePadding returns padding for the name.
 func (c *Command) NamePadding() int {
 	if c.parent == nil || minNamePadding > c.parent.commandsMaxNameLen {
 		return minNamePadding
@@ -285,6 +358,7 @@ func (c *Command) NamePadding() int {
 	return c.parent.commandsMaxNameLen
 }
 
+// UsageTemplate returns usage template for the command.
 func (c *Command) UsageTemplate() string {
 	if c.usageTemplate != "" {
 		return c.usageTemplate
@@ -294,32 +368,32 @@ func (c *Command) UsageTemplate() string {
 		return c.parent.UsageTemplate()
 	}
 	return `Usage:{{if .Runnable}}
-  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
-  {{.NameAndAliases}}
-{{end}}{{if .HasExample}}
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
 
-Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
-{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
-Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
 }
 
+// HelpTemplate return help template for the command.
 func (c *Command) HelpTemplate() string {
 	if c.helpTemplate != "" {
 		return c.helpTemplate
@@ -328,72 +402,60 @@ func (c *Command) HelpTemplate() string {
 	if c.HasParent() {
 		return c.parent.HelpTemplate()
 	}
-	return `{{with or .Long .Short }}{{. | trim}}
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 }
 
-// Really only used when casting a command to a commander
-func (c *Command) resetChildrensParents() {
-	for _, x := range c.commands {
-		x.parent = c
-	}
-}
-
-// Test if the named flag is a boolean flag.
-func isBooleanFlag(name string, f *flag.FlagSet) bool {
-	flag := f.Lookup(name)
+func hasNoOptDefVal(name string, fs *flag.FlagSet) bool {
+	flag := fs.Lookup(name)
 	if flag == nil {
 		return false
 	}
-	return flag.Value.Type() == "bool"
+	return flag.NoOptDefVal != ""
 }
 
-// Test if the named flag is a boolean flag.
-func isBooleanShortFlag(name string, f *flag.FlagSet) bool {
-	result := false
-	f.VisitAll(func(f *flag.Flag) {
-		if f.Shorthand == name && f.Value.Type() == "bool" {
-			result = true
-		}
-	})
-	return result
+func shortHasNoOptDefVal(name string, fs *flag.FlagSet) bool {
+	if len(name) == 0 {
+		return false
+	}
+
+	flag := fs.ShorthandLookup(name[:1])
+	if flag == nil {
+		return false
+	}
+	return flag.NoOptDefVal != ""
 }
 
 func stripFlags(args []string, c *Command) []string {
-	if len(args) < 1 {
+	if len(args) == 0 {
 		return args
 	}
 	c.mergePersistentFlags()
 
 	commands := []string{}
+	flags := c.Flags()
 
-	inQuote := false
-	inFlag := false
-	for _, y := range args {
-		if !inQuote {
-			switch {
-			case strings.HasPrefix(y, "\""):
-				inQuote = true
-			case strings.Contains(y, "=\""):
-				inQuote = true
-			case strings.HasPrefix(y, "--") && !strings.Contains(y, "="):
-				// TODO: this isn't quite right, we should really check ahead for 'true' or 'false'
-				inFlag = !isBooleanFlag(y[2:], c.Flags())
-			case strings.HasPrefix(y, "-") && !strings.Contains(y, "=") && len(y) == 2 && !isBooleanShortFlag(y[1:], c.Flags()):
-				inFlag = true
-			case inFlag:
-				inFlag = false
-			case y == "":
-				// strip empty commands, as the go tests expect this to be ok....
-			case !strings.HasPrefix(y, "-"):
-				commands = append(commands, y)
-				inFlag = false
+Loop:
+	for len(args) > 0 {
+		s := args[0]
+		args = args[1:]
+		switch {
+		case strings.HasPrefix(s, "--") && !strings.Contains(s, "=") && !hasNoOptDefVal(s[2:], flags):
+			// If '--flag arg' then
+			// delete arg from args.
+			fallthrough // (do the same as below)
+		case strings.HasPrefix(s, "-") && !strings.Contains(s, "=") && len(s) == 2 && !shortHasNoOptDefVal(s[1:], flags):
+			// If '-f arg' then
+			// delete 'arg' from args or break the loop if len(args) <= 1.
+			if len(args) <= 1 {
+				break Loop
+			} else {
+				args = args[1:]
+				continue
 			}
-		}
-
-		if strings.HasSuffix(y, "\"") && !strings.HasSuffix(y, "\\\"") {
-			inQuote = false
+		case s != "" && !strings.HasPrefix(s, "-"):
+			commands = append(commands, s)
 		}
 	}
 
@@ -414,13 +476,14 @@ func argsMinusFirstX(args []string, x string) []string {
 	return args
 }
 
-// find the target command given the args and command tree
+func isFlagArg(arg string) bool {
+	return ((len(arg) >= 3 && arg[1] == '-') ||
+		(len(arg) >= 2 && arg[0] == '-' && arg[1] != '-'))
+}
+
+// Find the target command given the args and command tree
 // Meant to be run on the highest node. Only searches down.
 func (c *Command) Find(args []string) (*Command, []string, error) {
-	if c == nil {
-		return nil, nil, fmt.Errorf("Called find() on a nil Command")
-	}
-
 	var innerfind func(*Command, []string) (*Command, []string)
 
 	innerfind = func(c *Command, innerArgs []string) (*Command, []string) {
@@ -429,59 +492,99 @@ func (c *Command) Find(args []string) (*Command, []string, error) {
 			return c, innerArgs
 		}
 		nextSubCmd := argsWOflags[0]
-		matches := make([]*Command, 0)
-		for _, cmd := range c.commands {
-			if cmd.Name() == nextSubCmd || cmd.HasAlias(nextSubCmd) { // exact name or alias match
-				return innerfind(cmd, argsMinusFirstX(innerArgs, nextSubCmd))
-			}
-			if EnablePrefixMatching {
-				if strings.HasPrefix(cmd.Name(), nextSubCmd) { // prefix match
-					matches = append(matches, cmd)
-				}
-				for _, x := range cmd.Aliases {
-					if strings.HasPrefix(x, nextSubCmd) {
-						matches = append(matches, cmd)
-					}
-				}
-			}
-		}
 
-		// only accept a single prefix match - multiple matches would be ambiguous
-		if len(matches) == 1 {
-			return innerfind(matches[0], argsMinusFirstX(innerArgs, argsWOflags[0]))
+		cmd := c.findNext(nextSubCmd)
+		if cmd != nil {
+			return innerfind(cmd, argsMinusFirstX(innerArgs, nextSubCmd))
 		}
-
 		return c, innerArgs
 	}
 
 	commandFound, a := innerfind(c, args)
-	argsWOflags := stripFlags(a, commandFound)
-
-	// no subcommand, always take args
-	if !commandFound.HasSubCommands() {
-		return commandFound, a, nil
+	if commandFound.Args == nil {
+		return commandFound, a, legacyArgs(commandFound, stripFlags(a, commandFound))
 	}
-
-	// root command with subcommands, do subcommand checking
-	if commandFound == c && len(argsWOflags) > 0 {
-		suggestionsString := ""
-		if !c.DisableSuggestions {
-			if c.SuggestionsMinimumDistance <= 0 {
-				c.SuggestionsMinimumDistance = 2
-			}
-			if suggestions := c.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
-				suggestionsString += "\n\nDid you mean this?\n"
-				for _, s := range suggestions {
-					suggestionsString += fmt.Sprintf("\t%v\n", s)
-				}
-			}
-		}
-		return commandFound, a, fmt.Errorf("unknown command %q for %q%s", argsWOflags[0], commandFound.CommandPath(), suggestionsString)
-	}
-
 	return commandFound, a, nil
 }
 
+func (c *Command) findSuggestions(arg string) string {
+	if c.DisableSuggestions {
+		return ""
+	}
+	if c.SuggestionsMinimumDistance <= 0 {
+		c.SuggestionsMinimumDistance = 2
+	}
+	suggestionsString := ""
+	if suggestions := c.SuggestionsFor(arg); len(suggestions) > 0 {
+		suggestionsString += "\n\nDid you mean this?\n"
+		for _, s := range suggestions {
+			suggestionsString += fmt.Sprintf("\t%v\n", s)
+		}
+	}
+	return suggestionsString
+}
+
+func (c *Command) findNext(next string) *Command {
+	matches := make([]*Command, 0)
+	for _, cmd := range c.commands {
+		if cmd.Name() == next || cmd.HasAlias(next) {
+			return cmd
+		}
+		if EnablePrefixMatching && cmd.hasNameOrAliasPrefix(next) {
+			matches = append(matches, cmd)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0]
+	}
+	return nil
+}
+
+// Traverse the command tree to find the command, and parse args for
+// each parent.
+func (c *Command) Traverse(args []string) (*Command, []string, error) {
+	flags := []string{}
+	inFlag := false
+
+	for i, arg := range args {
+		switch {
+		// A long flag with a space separated value
+		case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "="):
+			// TODO: this isn't quite right, we should really check ahead for 'true' or 'false'
+			inFlag = !hasNoOptDefVal(arg[2:], c.Flags())
+			flags = append(flags, arg)
+			continue
+		// A short flag with a space separated value
+		case strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && len(arg) == 2 && !shortHasNoOptDefVal(arg[1:], c.Flags()):
+			inFlag = true
+			flags = append(flags, arg)
+			continue
+		// The value for a flag
+		case inFlag:
+			inFlag = false
+			flags = append(flags, arg)
+			continue
+		// A flag without a value, or with an `=` separated value
+		case isFlagArg(arg):
+			flags = append(flags, arg)
+			continue
+		}
+
+		cmd := c.findNext(arg)
+		if cmd == nil {
+			return c, args, nil
+		}
+
+		if err := c.ParseFlags(flags); err != nil {
+			return nil, args, err
+		}
+		return cmd.Traverse(args[i+1:])
+	}
+	return c, args, nil
+}
+
+// SuggestionsFor provides suggestions for the typedName.
 func (c *Command) SuggestionsFor(typedName string) []string {
 	suggestions := []string{}
 	for _, cmd := range c.commands {
@@ -502,32 +605,20 @@ func (c *Command) SuggestionsFor(typedName string) []string {
 	return suggestions
 }
 
+// VisitParents visits all parents of the command and invokes fn on each parent.
 func (c *Command) VisitParents(fn func(*Command)) {
-	var traverse func(*Command) *Command
-
-	traverse = func(x *Command) *Command {
-		if x != c {
-			fn(x)
-		}
-		if x.HasParent() {
-			return traverse(x.parent)
-		}
-		return x
+	if c.HasParent() {
+		fn(c.Parent())
+		c.Parent().VisitParents(fn)
 	}
-	traverse(c)
 }
 
+// Root finds root command.
 func (c *Command) Root() *Command {
-	var findRoot func(*Command) *Command
-
-	findRoot = func(x *Command) *Command {
-		if x.HasParent() {
-			return findRoot(x.parent)
-		}
-		return x
+	if c.HasParent() {
+		return c.Parent().Root()
 	}
-
-	return findRoot(c)
+	return c
 }
 
 // ArgsLenAtDash will return the length of f.Args at the moment when a -- was
@@ -549,18 +640,19 @@ func (c *Command) execute(a []string) (err error) {
 
 	// initialize help flag as the last point possible to allow for user
 	// overriding
-	c.initHelpFlag()
+	c.InitDefaultHelpFlag()
 
 	err = c.ParseFlags(a)
 	if err != nil {
-		return err
+		return c.FlagErrorFunc()(c, err)
 	}
-	// If help is called, regardless of other flags, return we want help
+
+	// If help is called, regardless of other flags, return we want help.
 	// Also say we need help if the command isn't runnable.
 	helpVal, err := c.Flags().GetBool("help")
 	if err != nil {
 		// should be impossible to get here as we always declare a help
-		// flag in initHelpFlag()
+		// flag in InitDefaultHelpFlag()
 		c.Println("\"help\" flag declared as non-bool. Please correct your code")
 		return err
 	}
@@ -574,6 +666,10 @@ func (c *Command) execute(a []string) (err error) {
 	argWoFlags := c.Flags().Args()
 	if c.DisableFlagParsing {
 		argWoFlags = a
+	}
+
+	if err := c.ValidateArgs(argWoFlags); err != nil {
+		return err
 	}
 
 	for p := c; p != nil; p = p.Parent() {
@@ -595,6 +691,9 @@ func (c *Command) execute(a []string) (err error) {
 		c.PreRun(c, argWoFlags)
 	}
 
+	if err := c.validateRequiredFlags(); err != nil {
+		return err
+	}
 	if c.RunE != nil {
 		if err := c.RunE(c, argWoFlags); err != nil {
 			return err
@@ -630,18 +729,7 @@ func (c *Command) preRun() {
 	}
 }
 
-func (c *Command) errorMsgFromParse() string {
-	s := c.flagErrorBuf.String()
-
-	x := strings.Split(s, "\n")
-
-	if len(x) > 0 {
-		return x[0]
-	}
-	return ""
-}
-
-// Call execute to use the args (os.Args[1:] by default)
+// Execute uses the args (os.Args[1:] by default)
 // and run through the command tree finding appropriate matches
 // for commands and then corresponding flags.
 func (c *Command) Execute() error {
@@ -649,8 +737,8 @@ func (c *Command) Execute() error {
 	return err
 }
 
+// ExecuteC executes the command.
 func (c *Command) ExecuteC() (cmd *Command, err error) {
-
 	// Regardless of what command execute is called on, run on Root only
 	if c.HasParent() {
 		return c.Root().ExecuteC()
@@ -663,7 +751,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 
 	// initialize help as the last point possible to allow for user
 	// overriding
-	c.initHelpCmd()
+	c.InitDefaultHelpCmd()
 
 	var args []string
 
@@ -674,7 +762,12 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		args = c.args
 	}
 
-	cmd, flags, err := c.Find(args)
+	var flags []string
+	if c.TraverseChildren {
+		cmd, flags, err = c.Traverse(args)
+	} else {
+		cmd, flags, err = c.Find(args)
+	}
 	if err != nil {
 		// If found parse to a subcommand and then failed, talk about the subcommand
 		if cmd != nil {
@@ -686,6 +779,7 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		}
 		return c, err
 	}
+
 	err = cmd.execute(flags)
 	if err != nil {
 		// Always show help if requested, even if SilenceErrors is in
@@ -706,52 +800,92 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 		if !cmd.SilenceUsage && !c.SilenceUsage {
 			c.Println(cmd.UsageString())
 		}
-		return cmd, err
 	}
-	return cmd, nil
+	return cmd, err
 }
 
-func (c *Command) initHelpFlag() {
-	if c.Flags().Lookup("help") == nil {
-		c.Flags().BoolP("help", "h", false, "help for "+c.Name())
+func (c *Command) ValidateArgs(args []string) error {
+	if c.Args == nil {
+		return nil
 	}
+	return c.Args(c, args)
 }
 
-func (c *Command) initHelpCmd() {
-	if c.helpCommand == nil {
-		if !c.HasSubCommands() {
+func (c *Command) validateRequiredFlags() error {
+	flags := c.Flags()
+	missingFlagNames := []string{}
+	flags.VisitAll(func(pflag *flag.Flag) {
+		requiredAnnotation, found := pflag.Annotations[BashCompOneRequiredFlag]
+		if !found {
 			return
 		}
+		if (requiredAnnotation[0] == "true") && !pflag.Changed {
+			missingFlagNames = append(missingFlagNames, pflag.Name)
+		}
+	})
 
+	if len(missingFlagNames) > 0 {
+		return fmt.Errorf(`Required flag(s) "%s" have/has not been set`, strings.Join(missingFlagNames, `", "`))
+	}
+	return nil
+}
+
+// InitDefaultHelpFlag adds default help flag to c.
+// It is called automatically by executing the c or by calling help and usage.
+// If c already has help flag, it will do nothing.
+func (c *Command) InitDefaultHelpFlag() {
+	c.mergePersistentFlags()
+	if c.Flags().Lookup("help") == nil {
+		usage := "help for "
+		if c.Name() == "" {
+			usage += "this command"
+		} else {
+			usage += c.Name()
+		}
+		c.Flags().BoolP("help", "h", false, usage)
+	}
+}
+
+// InitDefaultHelpCmd adds default help command to c.
+// It is called automatically by executing the c or by calling help and usage.
+// If c already has help command or c has no subcommands, it will do nothing.
+func (c *Command) InitDefaultHelpCmd() {
+	if !c.HasSubCommands() {
+		return
+	}
+
+	if c.helpCommand == nil {
 		c.helpCommand = &Command{
 			Use:   "help [command]",
 			Short: "Help about any command",
 			Long: `Help provides help for any command in the application.
-    Simply type ` + c.Name() + ` help [path to command] for full details.`,
-			PersistentPreRun:  func(cmd *Command, args []string) {},
-			PersistentPostRun: func(cmd *Command, args []string) {},
+Simply type ` + c.Name() + ` help [path to command] for full details.`,
 
 			Run: func(c *Command, args []string) {
 				cmd, _, e := c.Root().Find(args)
 				if cmd == nil || e != nil {
-					c.Printf("Unknown help topic %#q.", args)
+					c.Printf("Unknown help topic %#q\n", args)
 					c.Root().Usage()
 				} else {
+					cmd.InitDefaultHelpFlag() // make possible 'help' flag to be shown
 					cmd.Help()
 				}
 			},
 		}
 	}
+	c.RemoveCommand(c.helpCommand)
 	c.AddCommand(c.helpCommand)
 }
 
-// Used for testing
+// ResetCommands used for testing.
 func (c *Command) ResetCommands() {
+	c.parent = nil
 	c.commands = nil
 	c.helpCommand = nil
+	c.parentsPflags = nil
 }
 
-// Sorts commands by their names
+// Sorts commands by their names.
 type commandSorterByName []*Command
 
 func (c commandSorterByName) Len() int           { return len(c) }
@@ -831,45 +965,45 @@ main:
 	}
 }
 
-// Print is a convenience method to Print to the defined output, fallback to Stderr if not set
+// Print is a convenience method to Print to the defined output, fallback to Stderr if not set.
 func (c *Command) Print(i ...interface{}) {
 	fmt.Fprint(c.OutOrStderr(), i...)
 }
 
-// Println is a convenience method to Println to the defined output, fallback to Stderr if not set
+// Println is a convenience method to Println to the defined output, fallback to Stderr if not set.
 func (c *Command) Println(i ...interface{}) {
-	str := fmt.Sprintln(i...)
-	c.Print(str)
+	c.Print(fmt.Sprintln(i...))
 }
 
-// Printf is a convenience method to Printf to the defined output, fallback to Stderr if not set
+// Printf is a convenience method to Printf to the defined output, fallback to Stderr if not set.
 func (c *Command) Printf(format string, i ...interface{}) {
-	str := fmt.Sprintf(format, i...)
-	c.Print(str)
+	c.Print(fmt.Sprintf(format, i...))
 }
 
 // CommandPath returns the full path to this command.
 func (c *Command) CommandPath() string {
-	str := c.Name()
-	x := c
-	for x.HasParent() {
-		str = x.parent.Name() + " " + str
-		x = x.parent
-	}
-	return str
-}
-
-//The full usage for a given command (including parents)
-func (c *Command) UseLine() string {
-	str := ""
 	if c.HasParent() {
-		str = c.parent.CommandPath() + " "
+		return c.Parent().CommandPath() + " " + c.Name()
 	}
-	return str + c.Use
+	return c.Name()
 }
 
-// For use in determining which flags have been assigned to which commands
-// and which persist
+// UseLine puts out the full usage for a given command (including parents).
+func (c *Command) UseLine() string {
+	var useline string
+	if c.HasParent() {
+		useline = c.parent.CommandPath() + " " + c.Use
+	} else {
+		useline = c.Use
+	}
+	if c.HasAvailableFlags() && !strings.Contains(useline, "[flags]") {
+		useline += " [flags]"
+	}
+	return useline
+}
+
+// DebugFlags used to determine which flags have been assigned to which commands
+// and which persist.
 func (c *Command) DebugFlags() {
 	c.Println("DebugFlags called on", c.Name())
 	var debugflags func(*Command)
@@ -880,12 +1014,8 @@ func (c *Command) DebugFlags() {
 		}
 		if x.HasFlags() {
 			x.flags.VisitAll(func(f *flag.Flag) {
-				if x.HasPersistentFlags() {
-					if x.persistentFlag(f.Name) == nil {
-						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
-					} else {
-						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
-					}
+				if x.HasPersistentFlags() && x.persistentFlag(f.Name) != nil {
+					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
 				} else {
 					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
 				}
@@ -915,9 +1045,6 @@ func (c *Command) DebugFlags() {
 
 // Name returns the command's name: the first word in the use line.
 func (c *Command) Name() string {
-	if c.name != "" {
-		return c.name
-	}
 	name := c.Use
 	i := strings.Index(name, " ")
 	if i >= 0 {
@@ -936,26 +1063,42 @@ func (c *Command) HasAlias(s string) bool {
 	return false
 }
 
+// hasNameOrAliasPrefix returns true if the Name or any of aliases start
+// with prefix
+func (c *Command) hasNameOrAliasPrefix(prefix string) bool {
+	if strings.HasPrefix(c.Name(), prefix) {
+		return true
+	}
+	for _, alias := range c.Aliases {
+		if strings.HasPrefix(alias, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// NameAndAliases returns a list of the command name and all aliases
 func (c *Command) NameAndAliases() string {
 	return strings.Join(append([]string{c.Name()}, c.Aliases...), ", ")
 }
 
+// HasExample determines if the command has example.
 func (c *Command) HasExample() bool {
 	return len(c.Example) > 0
 }
 
-// Runnable determines if the command is itself runnable
+// Runnable determines if the command is itself runnable.
 func (c *Command) Runnable() bool {
 	return c.Run != nil || c.RunE != nil
 }
 
-// HasSubCommands determines if the command has children commands
+// HasSubCommands determines if the command has children commands.
 func (c *Command) HasSubCommands() bool {
 	return len(c.commands) > 0
 }
 
 // IsAvailableCommand determines if a command is available as a non-help command
-// (this includes all non deprecated/hidden commands)
+// (this includes all non deprecated/hidden commands).
 func (c *Command) IsAvailableCommand() bool {
 	if len(c.Deprecated) != 0 || c.Hidden {
 		return false
@@ -972,11 +1115,12 @@ func (c *Command) IsAvailableCommand() bool {
 	return false
 }
 
-// IsHelpCommand determines if a command is a 'help' command; a help command is
-// determined by the fact that it is NOT runnable/hidden/deprecated, and has no
-// sub commands that are runnable/hidden/deprecated
-func (c *Command) IsHelpCommand() bool {
-
+// IsAdditionalHelpTopicCommand determines if a command is an additional
+// help topic command; additional help topic command is determined by the
+// fact that it is NOT runnable/hidden/deprecated, and has no sub commands that
+// are runnable/hidden/deprecated.
+// Concrete example: https://github.com/spf13/cobra/issues/393#issuecomment-282741924.
+func (c *Command) IsAdditionalHelpTopicCommand() bool {
 	// if a command is runnable, deprecated, or hidden it is not a 'help' command
 	if c.Runnable() || len(c.Deprecated) != 0 || c.Hidden {
 		return false
@@ -984,7 +1128,7 @@ func (c *Command) IsHelpCommand() bool {
 
 	// if any non-help sub commands are found, the command is not a 'help' command
 	for _, sub := range c.commands {
-		if !sub.IsHelpCommand() {
+		if !sub.IsAdditionalHelpTopicCommand() {
 			return false
 		}
 	}
@@ -993,14 +1137,13 @@ func (c *Command) IsHelpCommand() bool {
 	return true
 }
 
-// HasHelpSubCommands determines if a command has any avilable 'help' sub commands
+// HasHelpSubCommands determines if a command has any available 'help' sub commands
 // that need to be shown in the usage/help default template under 'additional help
-// topics'
+// topics'.
 func (c *Command) HasHelpSubCommands() bool {
-
 	// return true on the first found available 'help' sub command
 	for _, sub := range c.commands {
-		if sub.IsHelpCommand() {
+		if sub.IsAdditionalHelpTopicCommand() {
 			return true
 		}
 	}
@@ -1010,9 +1153,8 @@ func (c *Command) HasHelpSubCommands() bool {
 }
 
 // HasAvailableSubCommands determines if a command has available sub commands that
-// need to be shown in the usage/help default template under 'available commands'
+// need to be shown in the usage/help default template under 'available commands'.
 func (c *Command) HasAvailableSubCommands() bool {
-
 	// return true on the first found available (non deprecated/help/hidden)
 	// sub command
 	for _, sub := range c.commands {
@@ -1026,17 +1168,18 @@ func (c *Command) HasAvailableSubCommands() bool {
 	return false
 }
 
-// Determine if the command is a child command
+// HasParent determines if the command is a child command.
 func (c *Command) HasParent() bool {
 	return c.parent != nil
 }
 
-// GlobalNormalizationFunc returns the global normalization function or nil if doesn't exists
+// GlobalNormalizationFunc returns the global normalization function or nil if doesn't exists.
 func (c *Command) GlobalNormalizationFunc() func(f *flag.FlagSet, name string) flag.NormalizedName {
 	return c.globNormFunc
 }
 
-// Get the complete FlagSet that applies to this command (local and persistent declared here and by all parents)
+// Flags returns the complete FlagSet that applies
+// to this command (local and persistent declared here and by all parents).
 func (c *Command) Flags() *flag.FlagSet {
 	if c.flags == nil {
 		c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
@@ -1045,10 +1188,11 @@ func (c *Command) Flags() *flag.FlagSet {
 		}
 		c.flags.SetOutput(c.flagErrorBuf)
 	}
+
 	return c.flags
 }
 
-// LocalNonPersistentFlags are flags specific to this command which will NOT persist to subcommands
+// LocalNonPersistentFlags are flags specific to this command which will NOT persist to subcommands.
 func (c *Command) LocalNonPersistentFlags() *flag.FlagSet {
 	persistentFlags := c.PersistentFlags()
 
@@ -1061,59 +1205,63 @@ func (c *Command) LocalNonPersistentFlags() *flag.FlagSet {
 	return out
 }
 
-// Get the local FlagSet specifically set in the current command
+// LocalFlags returns the local FlagSet specifically set in the current command.
 func (c *Command) LocalFlags() *flag.FlagSet {
 	c.mergePersistentFlags()
 
-	local := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-	c.lflags.VisitAll(func(f *flag.Flag) {
-		local.AddFlag(f)
-	})
-	if !c.HasParent() {
-		flag.CommandLine.VisitAll(func(f *flag.Flag) {
-			if local.Lookup(f.Name) == nil {
-				local.AddFlag(f)
-			}
-		})
+	if c.lflags == nil {
+		c.lflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.lflags.SetOutput(c.flagErrorBuf)
 	}
-	return local
+	c.lflags.SortFlags = c.Flags().SortFlags
+	if c.globNormFunc != nil {
+		c.lflags.SetNormalizeFunc(c.globNormFunc)
+	}
+
+	addToLocal := func(f *flag.Flag) {
+		if c.lflags.Lookup(f.Name) == nil && c.parentsPflags.Lookup(f.Name) == nil {
+			c.lflags.AddFlag(f)
+		}
+	}
+	c.Flags().VisitAll(addToLocal)
+	c.PersistentFlags().VisitAll(addToLocal)
+	return c.lflags
 }
 
-// All Flags which were inherited from parents commands
+// InheritedFlags returns all flags which were inherited from parents commands.
 func (c *Command) InheritedFlags() *flag.FlagSet {
 	c.mergePersistentFlags()
 
-	inherited := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	if c.iflags == nil {
+		c.iflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.iflags.SetOutput(c.flagErrorBuf)
+	}
+
 	local := c.LocalFlags()
-
-	var rmerge func(x *Command)
-
-	rmerge = func(x *Command) {
-		if x.HasPersistentFlags() {
-			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
-				if inherited.Lookup(f.Name) == nil && local.Lookup(f.Name) == nil {
-					inherited.AddFlag(f)
-				}
-			})
-		}
-		if x.HasParent() {
-			rmerge(x.parent)
-		}
+	if c.globNormFunc != nil {
+		c.iflags.SetNormalizeFunc(c.globNormFunc)
 	}
 
-	if c.HasParent() {
-		rmerge(c.parent)
-	}
-
-	return inherited
+	c.parentsPflags.VisitAll(func(f *flag.Flag) {
+		if c.iflags.Lookup(f.Name) == nil && local.Lookup(f.Name) == nil {
+			c.iflags.AddFlag(f)
+		}
+	})
+	return c.iflags
 }
 
-// All Flags which were not inherited from parent commands
+// NonInheritedFlags returns all flags which were not inherited from parent commands.
 func (c *Command) NonInheritedFlags() *flag.FlagSet {
 	return c.LocalFlags()
 }
 
-// Get the Persistent FlagSet specifically set in the current command
+// PersistentFlags returns the persistent FlagSet specifically set in the current command.
 func (c *Command) PersistentFlags() *flag.FlagSet {
 	if c.pflags == nil {
 		c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
@@ -1125,7 +1273,7 @@ func (c *Command) PersistentFlags() *flag.FlagSet {
 	return c.pflags
 }
 
-// For use in testing
+// ResetFlags is used in testing.
 func (c *Command) ResetFlags() {
 	c.flagErrorBuf = new(bytes.Buffer)
 	c.flagErrorBuf.Reset()
@@ -1133,52 +1281,56 @@ func (c *Command) ResetFlags() {
 	c.flags.SetOutput(c.flagErrorBuf)
 	c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	c.pflags.SetOutput(c.flagErrorBuf)
+
+	c.lflags = nil
+	c.iflags = nil
+	c.parentsPflags = nil
 }
 
-// Does the command contain any flags (local plus persistent from the entire structure)
+// HasFlags checks if the command contains any flags (local plus persistent from the entire structure).
 func (c *Command) HasFlags() bool {
 	return c.Flags().HasFlags()
 }
 
-// Does the command contain persistent flags
+// HasPersistentFlags checks if the command contains persistent flags.
 func (c *Command) HasPersistentFlags() bool {
 	return c.PersistentFlags().HasFlags()
 }
 
-// Does the command has flags specifically declared locally
+// HasLocalFlags checks if the command has flags specifically declared locally.
 func (c *Command) HasLocalFlags() bool {
 	return c.LocalFlags().HasFlags()
 }
 
-// Does the command have flags inherited from its parent command
+// HasInheritedFlags checks if the command has flags inherited from its parent command.
 func (c *Command) HasInheritedFlags() bool {
 	return c.InheritedFlags().HasFlags()
 }
 
-// Does the command contain any flags (local plus persistent from the entire
-// structure) which are not hidden or deprecated
+// HasAvailableFlags checks if the command contains any flags (local plus persistent from the entire
+// structure) which are not hidden or deprecated.
 func (c *Command) HasAvailableFlags() bool {
 	return c.Flags().HasAvailableFlags()
 }
 
-// Does the command contain persistent flags which are not hidden or deprecated
+// HasAvailablePersistentFlags checks if the command contains persistent flags which are not hidden or deprecated.
 func (c *Command) HasAvailablePersistentFlags() bool {
 	return c.PersistentFlags().HasAvailableFlags()
 }
 
-// Does the command has flags specifically declared locally which are not hidden
-// or deprecated
+// HasAvailableLocalFlags checks if the command has flags specifically declared locally which are not hidden
+// or deprecated.
 func (c *Command) HasAvailableLocalFlags() bool {
 	return c.LocalFlags().HasAvailableFlags()
 }
 
-// Does the command have flags inherited from its parent command which are
-// not hidden or deprecated
+// HasAvailableInheritedFlags checks if the command has flags inherited from its parent command which are
+// not hidden or deprecated.
 func (c *Command) HasAvailableInheritedFlags() bool {
 	return c.InheritedFlags().HasAvailableFlags()
 }
 
-// Flag climbs up the command tree looking for matching flag
+// Flag climbs up the command tree looking for matching flag.
 func (c *Command) Flag(name string) (flag *flag.Flag) {
 	flag = c.Flags().Lookup(name)
 
@@ -1189,68 +1341,69 @@ func (c *Command) Flag(name string) (flag *flag.Flag) {
 	return
 }
 
-// recursively find matching persistent flag
+// Recursively find matching persistent flag.
 func (c *Command) persistentFlag(name string) (flag *flag.Flag) {
 	if c.HasPersistentFlags() {
 		flag = c.PersistentFlags().Lookup(name)
 	}
 
-	if flag == nil && c.HasParent() {
-		flag = c.parent.persistentFlag(name)
+	if flag == nil {
+		c.updateParentsPflags()
+		flag = c.parentsPflags.Lookup(name)
 	}
 	return
 }
 
-// ParseFlags parses persistent flag tree & local flags
-func (c *Command) ParseFlags(args []string) (err error) {
+// ParseFlags parses persistent flag tree and local flags.
+func (c *Command) ParseFlags(args []string) error {
 	if c.DisableFlagParsing {
 		return nil
 	}
+
+	if c.flagErrorBuf == nil {
+		c.flagErrorBuf = new(bytes.Buffer)
+	}
+	beforeErrorBufLen := c.flagErrorBuf.Len()
 	c.mergePersistentFlags()
-	err = c.Flags().Parse(args)
-	return
+	err := c.Flags().Parse(args)
+	// Print warnings if they occurred (e.g. deprecated flag messages).
+	if c.flagErrorBuf.Len()-beforeErrorBufLen > 0 && err == nil {
+		c.Print(c.flagErrorBuf.String())
+	}
+
+	return err
 }
 
-// Parent returns a commands parent command
+// Parent returns a commands parent command.
 func (c *Command) Parent() *Command {
 	return c.parent
 }
 
+// mergePersistentFlags merges c.PersistentFlags() to c.Flags()
+// and adds missing persistent flags of all parents.
 func (c *Command) mergePersistentFlags() {
-	var rmerge func(x *Command)
+	c.updateParentsPflags()
+	c.Flags().AddFlagSet(c.PersistentFlags())
+	c.Flags().AddFlagSet(c.parentsPflags)
+}
 
-	// Save the set of local flags
-	if c.lflags == nil {
-		c.lflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-		if c.flagErrorBuf == nil {
-			c.flagErrorBuf = new(bytes.Buffer)
-		}
-		c.lflags.SetOutput(c.flagErrorBuf)
-		addtolocal := func(f *flag.Flag) {
-			c.lflags.AddFlag(f)
-		}
-		c.Flags().VisitAll(addtolocal)
-		c.PersistentFlags().VisitAll(addtolocal)
-	}
-	rmerge = func(x *Command) {
-		if !x.HasParent() {
-			flag.CommandLine.VisitAll(func(f *flag.Flag) {
-				if x.PersistentFlags().Lookup(f.Name) == nil {
-					x.PersistentFlags().AddFlag(f)
-				}
-			})
-		}
-		if x.HasPersistentFlags() {
-			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
-				if c.Flags().Lookup(f.Name) == nil {
-					c.Flags().AddFlag(f)
-				}
-			})
-		}
-		if x.HasParent() {
-			rmerge(x.parent)
-		}
+// updateParentsPflags updates c.parentsPflags by adding
+// new persistent flags of all parents.
+// If c.parentsPflags == nil, it makes new.
+func (c *Command) updateParentsPflags() {
+	if c.parentsPflags == nil {
+		c.parentsPflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		c.parentsPflags.SetOutput(c.flagErrorBuf)
+		c.parentsPflags.SortFlags = false
 	}
 
-	rmerge(c)
+	if c.globNormFunc != nil {
+		c.parentsPflags.SetNormalizeFunc(c.globNormFunc)
+	}
+
+	c.Root().PersistentFlags().AddFlagSet(flag.CommandLine)
+
+	c.VisitParents(func(parent *Command) {
+		c.parentsPflags.AddFlagSet(parent.PersistentFlags())
+	})
 }

--- a/vendor/github.com/spf13/cobra/command_test.go
+++ b/vendor/github.com/spf13/cobra/command_test.go
@@ -1,9 +1,14 @@
 package cobra
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 // test to ensure hidden commands run as intended
@@ -114,8 +119,7 @@ func TestStripFlags(t *testing.T) {
 	}
 }
 
-func Test_DisableFlagParsing(t *testing.T) {
-	as := []string{"-v", "-race", "-file", "foo.go"}
+func TestDisableFlagParsing(t *testing.T) {
 	targs := []string{}
 	cmdPrint := &Command{
 		DisableFlagParsing: true,
@@ -123,14 +127,28 @@ func Test_DisableFlagParsing(t *testing.T) {
 			targs = args
 		},
 	}
-	osargs := []string{"cmd"}
-	os.Args = append(osargs, as...)
+	args := []string{"cmd", "-v", "-race", "-file", "foo.go"}
+	cmdPrint.SetArgs(args)
 	err := cmdPrint.Execute()
 	if err != nil {
 		t.Error(err)
 	}
-	if !reflect.DeepEqual(as, targs) {
-		t.Errorf("expected: %v, got: %v", as, targs)
+	if !reflect.DeepEqual(args, targs) {
+		t.Errorf("expected: %v, got: %v", args, targs)
+	}
+}
+
+func TestInitHelpFlagMergesFlags(t *testing.T) {
+	usage := "custom flag"
+	baseCmd := Command{Use: "testcmd"}
+	baseCmd.PersistentFlags().Bool("help", false, usage)
+	cmd := Command{Use: "do"}
+	baseCmd.AddCommand(&cmd)
+
+	cmd.InitDefaultHelpFlag()
+	actual := cmd.Flags().Lookup("help").Usage
+	if actual != usage {
+		t.Fatalf("Expected the help flag from the base command with usage '%s', but got the default with usage '%s'", usage, actual)
 	}
 }
 
@@ -142,11 +160,11 @@ func TestCommandsAreSorted(t *testing.T) {
 
 	var tmpCommand = &Command{Use: "tmp"}
 
-	for _, name := range(originalNames) {
+	for _, name := range originalNames {
 		tmpCommand.AddCommand(&Command{Use: name})
 	}
 
-	for i, c := range(tmpCommand.Commands()) {
+	for i, c := range tmpCommand.Commands() {
 		if expectedNames[i] != c.Name() {
 			t.Errorf("expected: %s, got: %s", expectedNames[i], c.Name())
 		}
@@ -162,15 +180,347 @@ func TestEnableCommandSortingIsDisabled(t *testing.T) {
 
 	var tmpCommand = &Command{Use: "tmp"}
 
-	for _, name := range(originalNames) {
+	for _, name := range originalNames {
 		tmpCommand.AddCommand(&Command{Use: name})
 	}
 
-	for i, c := range(tmpCommand.Commands()) {
+	for i, c := range tmpCommand.Commands() {
 		if originalNames[i] != c.Name() {
 			t.Errorf("expected: %s, got: %s", originalNames[i], c.Name())
 		}
 	}
 
 	EnableCommandSorting = true
+}
+
+func TestSetOutput(t *testing.T) {
+	cmd := &Command{}
+	cmd.SetOutput(nil)
+	if out := cmd.OutOrStdout(); out != os.Stdout {
+		t.Fatalf("expected setting output to nil to revert back to stdout, got %v", out)
+	}
+}
+
+func TestFlagErrorFunc(t *testing.T) {
+	cmd := &Command{
+		Use: "print",
+		RunE: func(cmd *Command, args []string) error {
+			return nil
+		},
+	}
+	expectedFmt := "This is expected: %s"
+
+	cmd.SetFlagErrorFunc(func(c *Command, err error) error {
+		return fmt.Errorf(expectedFmt, err)
+	})
+	cmd.SetArgs([]string{"--bogus-flag"})
+	cmd.SetOutput(new(bytes.Buffer))
+
+	err := cmd.Execute()
+
+	expected := fmt.Sprintf(expectedFmt, "unknown flag: --bogus-flag")
+	if err.Error() != expected {
+		t.Errorf("expected %v, got %v", expected, err.Error())
+	}
+}
+
+// TestSortedFlags checks,
+// if cmd.LocalFlags() is unsorted when cmd.Flags().SortFlags set to false.
+// Related to https://github.com/spf13/cobra/issues/404.
+func TestSortedFlags(t *testing.T) {
+	cmd := &Command{}
+	cmd.Flags().SortFlags = false
+	names := []string{"C", "B", "A", "D"}
+	for _, name := range names {
+		cmd.Flags().Bool(name, false, "")
+	}
+
+	i := 0
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if i == len(names) {
+			return
+		}
+		if isStringInStringSlice(f.Name, names) {
+			if names[i] != f.Name {
+				t.Errorf("Incorrect order. Expected %v, got %v", names[i], f.Name)
+			}
+			i++
+		}
+	})
+}
+
+// contains checks, if s is in ss.
+func isStringInStringSlice(s string, ss []string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHelpFlagInHelp checks,
+// if '--help' flag is shown in help for child (executing `parent help child`),
+// that has no other flags.
+// Related to https://github.com/spf13/cobra/issues/302.
+func TestHelpFlagInHelp(t *testing.T) {
+	output := new(bytes.Buffer)
+	parent := &Command{Use: "parent", Run: func(*Command, []string) {}}
+	parent.SetOutput(output)
+
+	child := &Command{Use: "child", Run: func(*Command, []string) {}}
+	parent.AddCommand(child)
+
+	parent.SetArgs([]string{"help", "child"})
+	err := parent.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(output.String(), "[flags]") {
+		t.Errorf("\nExpecting to contain: %v\nGot: %v", "[flags]", output.String())
+	}
+}
+
+// TestMergeCommandLineToFlags checks,
+// if pflag.CommandLine is correctly merged to c.Flags() after first call
+// of c.mergePersistentFlags.
+// Related to https://github.com/spf13/cobra/issues/443.
+func TestMergeCommandLineToFlags(t *testing.T) {
+	pflag.Bool("boolflag", false, "")
+	c := &Command{Use: "c", Run: func(*Command, []string) {}}
+	c.mergePersistentFlags()
+	if c.Flags().Lookup("boolflag") == nil {
+		t.Fatal("Expecting to have flag from CommandLine in c.Flags()")
+	}
+
+	// Reset pflag.CommandLine flagset.
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+}
+
+// TestUseDeprecatedFlags checks,
+// if cobra.Execute() prints a message, if a deprecated flag is used.
+// Related to https://github.com/spf13/cobra/issues/463.
+func TestUseDeprecatedFlags(t *testing.T) {
+	c := &Command{Use: "c", Run: func(*Command, []string) {}}
+	output := new(bytes.Buffer)
+	c.SetOutput(output)
+	c.Flags().BoolP("deprecated", "d", false, "deprecated flag")
+	c.Flags().MarkDeprecated("deprecated", "This flag is deprecated")
+
+	c.SetArgs([]string{"c", "-d"})
+	if err := c.Execute(); err != nil {
+		t.Error("Unexpected error:", err)
+	}
+	if !strings.Contains(output.String(), "This flag is deprecated") {
+		t.Errorf("Expected to contain deprecated message, but got %q", output.String())
+	}
+}
+
+// TestSetHelpCommand checks, if SetHelpCommand works correctly.
+func TestSetHelpCommand(t *testing.T) {
+	c := &Command{Use: "c", Run: func(*Command, []string) {}}
+	output := new(bytes.Buffer)
+	c.SetOutput(output)
+	c.SetArgs([]string{"help"})
+
+	// Help will not be shown, if c has no subcommands.
+	c.AddCommand(&Command{
+		Use: "empty",
+		Run: func(cmd *Command, args []string) {},
+	})
+
+	correctMessage := "WORKS"
+	c.SetHelpCommand(&Command{
+		Use:   "help [command]",
+		Short: "Help about any command",
+		Long: `Help provides help for any command in the application.
+	Simply type ` + c.Name() + ` help [path to command] for full details.`,
+		Run: func(c *Command, args []string) { c.Print(correctMessage) },
+	})
+
+	if err := c.Execute(); err != nil {
+		t.Error("Unexpected error:", err)
+	}
+
+	if output.String() != correctMessage {
+		t.Errorf("Expected to contain %q message, but got %q", correctMessage, output.String())
+	}
+}
+
+func TestTraverseWithParentFlags(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+	cmd.Flags().String("foo", "", "foo things")
+	cmd.Flags().BoolP("goo", "g", false, "foo things")
+
+	sub := &Command{Use: "next"}
+	sub.Flags().String("add", "", "add things")
+	cmd.AddCommand(sub)
+
+	c, args, err := cmd.Traverse([]string{"-g", "--foo", "ok", "next", "--add"})
+	if err != nil {
+		t.Fatalf("Expected no error: %s", err)
+	}
+	if len(args) != 1 && args[0] != "--add" {
+		t.Fatalf("wrong args %s", args)
+	}
+	if c.Name() != sub.Name() {
+		t.Fatalf("wrong command %q expected %q", c.Name(), sub.Name())
+	}
+}
+
+func TestTraverseNoParentFlags(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+	cmd.Flags().String("foo", "", "foo things")
+
+	sub := &Command{Use: "next"}
+	sub.Flags().String("add", "", "add things")
+	cmd.AddCommand(sub)
+
+	c, args, err := cmd.Traverse([]string{"next"})
+	if err != nil {
+		t.Fatalf("Expected no error: %s", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("wrong args %s", args)
+	}
+	if c.Name() != sub.Name() {
+		t.Fatalf("wrong command %q expected %q", c.Name(), sub.Name())
+	}
+}
+
+func TestTraverseWithBadParentFlags(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+	sub := &Command{Use: "next"}
+	sub.Flags().String("add", "", "add things")
+	cmd.AddCommand(sub)
+
+	expected := "got unknown flag: --add"
+
+	c, _, err := cmd.Traverse([]string{"--add", "ok", "next"})
+	if err == nil || strings.Contains(err.Error(), expected) {
+		t.Fatalf("Expected error %s got %s", expected, err)
+	}
+	if c != nil {
+		t.Fatalf("Expected nil command")
+	}
+}
+
+func TestTraverseWithBadChildFlag(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+	cmd.Flags().String("foo", "", "foo things")
+
+	sub := &Command{Use: "next"}
+	cmd.AddCommand(sub)
+
+	// Expect no error because the last commands args shouldn't be parsed in
+	// Traverse
+	c, args, err := cmd.Traverse([]string{"next", "--add"})
+	if err != nil {
+		t.Fatalf("Expected no error: %s", err)
+	}
+	if len(args) != 1 && args[0] != "--add" {
+		t.Fatalf("wrong args %s", args)
+	}
+	if c.Name() != sub.Name() {
+		t.Fatalf("wrong command %q expected %q", c.Name(), sub.Name())
+	}
+}
+
+func TestTraverseWithTwoSubcommands(t *testing.T) {
+	cmd := &Command{
+		Use:              "do",
+		TraverseChildren: true,
+	}
+
+	sub := &Command{
+		Use:              "sub",
+		TraverseChildren: true,
+	}
+	cmd.AddCommand(sub)
+
+	subsub := &Command{
+		Use: "subsub",
+	}
+	sub.AddCommand(subsub)
+
+	c, _, err := cmd.Traverse([]string{"sub", "subsub"})
+	if err != nil {
+		t.Fatalf("Expected no error: %s", err)
+	}
+	if c.Name() != subsub.Name() {
+		t.Fatalf("wrong command %q expected %q", c.Name(), subsub.Name())
+	}
+}
+
+func TestRequiredFlags(t *testing.T) {
+	c := &Command{Use: "c", Run: func(*Command, []string) {}}
+	output := new(bytes.Buffer)
+	c.SetOutput(output)
+	c.Flags().String("foo1", "", "required foo1")
+	c.MarkFlagRequired("foo1")
+	c.Flags().String("foo2", "", "required foo2")
+	c.MarkFlagRequired("foo2")
+	c.Flags().String("bar", "", "optional bar")
+
+	expected := fmt.Sprintf("Required flag(s) %q, %q have/has not been set", "foo1", "foo2")
+
+	if err := c.Execute(); err != nil {
+		if err.Error() != expected {
+			t.Errorf("expected %v, got %v", expected, err.Error())
+		}
+	}
+}
+
+func TestPersistentRequiredFlags(t *testing.T) {
+	parent := &Command{Use: "parent", Run: func(*Command, []string) {}}
+	output := new(bytes.Buffer)
+	parent.SetOutput(output)
+	parent.PersistentFlags().String("foo1", "", "required foo1")
+	parent.MarkPersistentFlagRequired("foo1")
+	parent.PersistentFlags().String("foo2", "", "required foo2")
+	parent.MarkPersistentFlagRequired("foo2")
+	parent.Flags().String("foo3", "", "optional foo3")
+
+	child := &Command{Use: "child", Run: func(*Command, []string) {}}
+	child.Flags().String("bar1", "", "required bar1")
+	child.MarkFlagRequired("bar1")
+	child.Flags().String("bar2", "", "required bar2")
+	child.MarkFlagRequired("bar2")
+	child.Flags().String("bar3", "", "optional bar3")
+
+	parent.AddCommand(child)
+	parent.SetArgs([]string{"child"})
+
+	expected := fmt.Sprintf("Required flag(s) %q, %q, %q, %q have/has not been set", "bar1", "bar2", "foo1", "foo2")
+
+	if err := parent.Execute(); err != nil {
+		if err.Error() != expected {
+			t.Errorf("expected %v, got %v", expected, err.Error())
+		}
+	}
+}
+
+// TestUpdateName checks if c.Name() updates on changed c.Use.
+// Related to https://github.com/spf13/cobra/pull/422#discussion_r143918343.
+func TestUpdateName(t *testing.T) {
+	c := &Command{Use: "name xyz"}
+	originalName := c.Name()
+
+	c.Use = "changedName abc"
+	if originalName == c.Name() || c.Name() != "changedName" {
+		t.Error("c.Name() should be updated on changed c.Use")
+	}
 }

--- a/vendor/github.com/spf13/cobra/command_win.go
+++ b/vendor/github.com/spf13/cobra/command_win.go
@@ -11,14 +11,8 @@ import (
 
 var preExecHookFn = preExecHook
 
-// enables an information splash screen on Windows if the CLI is started from explorer.exe.
-var MousetrapHelpText string = `This is a command line tool
-
-You need to open cmd.exe and run it from there.
-`
-
 func preExecHook(c *Command) {
-	if mousetrap.StartedByExplorer() {
+	if MousetrapHelpText != "" && mousetrap.StartedByExplorer() {
 		c.Print(MousetrapHelpText)
 		time.Sleep(5 * time.Second)
 		os.Exit(1)

--- a/vendor/github.com/spf13/cobra/zsh_completions.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions.go
@@ -1,0 +1,126 @@
+package cobra
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// GenZshCompletionFile generates zsh completion file.
+func (c *Command) GenZshCompletionFile(filename string) error {
+	outFile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	return c.GenZshCompletion(outFile)
+}
+
+// GenZshCompletion generates a zsh completion file and writes to the passed writer.
+func (c *Command) GenZshCompletion(w io.Writer) error {
+	buf := new(bytes.Buffer)
+
+	writeHeader(buf, c)
+	maxDepth := maxDepth(c)
+	writeLevelMapping(buf, maxDepth)
+	writeLevelCases(buf, maxDepth, c)
+
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+func writeHeader(w io.Writer, cmd *Command) {
+	fmt.Fprintf(w, "#compdef %s\n\n", cmd.Name())
+}
+
+func maxDepth(c *Command) int {
+	if len(c.Commands()) == 0 {
+		return 0
+	}
+	maxDepthSub := 0
+	for _, s := range c.Commands() {
+		subDepth := maxDepth(s)
+		if subDepth > maxDepthSub {
+			maxDepthSub = subDepth
+		}
+	}
+	return 1 + maxDepthSub
+}
+
+func writeLevelMapping(w io.Writer, numLevels int) {
+	fmt.Fprintln(w, `_arguments \`)
+	for i := 1; i <= numLevels; i++ {
+		fmt.Fprintf(w, `  '%d: :->level%d' \`, i, i)
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, `  '%d: :%s'`, numLevels+1, "_files")
+	fmt.Fprintln(w)
+}
+
+func writeLevelCases(w io.Writer, maxDepth int, root *Command) {
+	fmt.Fprintln(w, "case $state in")
+	defer fmt.Fprintln(w, "esac")
+
+	for i := 1; i <= maxDepth; i++ {
+		fmt.Fprintf(w, "  level%d)\n", i)
+		writeLevel(w, root, i)
+		fmt.Fprintln(w, "  ;;")
+	}
+	fmt.Fprintln(w, "  *)")
+	fmt.Fprintln(w, "    _arguments '*: :_files'")
+	fmt.Fprintln(w, "  ;;")
+}
+
+func writeLevel(w io.Writer, root *Command, i int) {
+	fmt.Fprintf(w, "    case $words[%d] in\n", i)
+	defer fmt.Fprintln(w, "    esac")
+
+	commands := filterByLevel(root, i)
+	byParent := groupByParent(commands)
+
+	for p, c := range byParent {
+		names := names(c)
+		fmt.Fprintf(w, "      %s)\n", p)
+		fmt.Fprintf(w, "        _arguments '%d: :(%s)'\n", i, strings.Join(names, " "))
+		fmt.Fprintln(w, "      ;;")
+	}
+	fmt.Fprintln(w, "      *)")
+	fmt.Fprintln(w, "        _arguments '*: :_files'")
+	fmt.Fprintln(w, "      ;;")
+
+}
+
+func filterByLevel(c *Command, l int) []*Command {
+	cs := make([]*Command, 0)
+	if l == 0 {
+		cs = append(cs, c)
+		return cs
+	}
+	for _, s := range c.Commands() {
+		cs = append(cs, filterByLevel(s, l-1)...)
+	}
+	return cs
+}
+
+func groupByParent(commands []*Command) map[string][]*Command {
+	m := make(map[string][]*Command)
+	for _, c := range commands {
+		parent := c.Parent()
+		if parent == nil {
+			continue
+		}
+		m[parent.Name()] = append(m[parent.Name()], c)
+	}
+	return m
+}
+
+func names(commands []*Command) []string {
+	ns := make([]string, len(commands))
+	for i, c := range commands {
+		ns[i] = c.Name()
+	}
+	return ns
+}

--- a/vendor/github.com/spf13/cobra/zsh_completions_test.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions_test.go
@@ -1,0 +1,88 @@
+package cobra
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestZshCompletion(t *testing.T) {
+	tcs := []struct {
+		name                string
+		root                *Command
+		expectedExpressions []string
+	}{
+		{
+			name:                "trivial",
+			root:                &Command{Use: "trivialapp"},
+			expectedExpressions: []string{"#compdef trivial"},
+		},
+		{
+			name: "linear",
+			root: func() *Command {
+				r := &Command{Use: "linear"}
+
+				sub1 := &Command{Use: "sub1"}
+				r.AddCommand(sub1)
+
+				sub2 := &Command{Use: "sub2"}
+				sub1.AddCommand(sub2)
+
+				sub3 := &Command{Use: "sub3"}
+				sub2.AddCommand(sub3)
+				return r
+			}(),
+			expectedExpressions: []string{"sub1", "sub2", "sub3"},
+		},
+		{
+			name: "flat",
+			root: func() *Command {
+				r := &Command{Use: "flat"}
+				r.AddCommand(&Command{Use: "c1"})
+				r.AddCommand(&Command{Use: "c2"})
+				return r
+			}(),
+			expectedExpressions: []string{"(c1 c2)"},
+		},
+		{
+			name: "tree",
+			root: func() *Command {
+				r := &Command{Use: "tree"}
+
+				sub1 := &Command{Use: "sub1"}
+				r.AddCommand(sub1)
+
+				sub11 := &Command{Use: "sub11"}
+				sub12 := &Command{Use: "sub12"}
+
+				sub1.AddCommand(sub11)
+				sub1.AddCommand(sub12)
+
+				sub2 := &Command{Use: "sub2"}
+				r.AddCommand(sub2)
+
+				sub21 := &Command{Use: "sub21"}
+				sub22 := &Command{Use: "sub22"}
+
+				sub2.AddCommand(sub21)
+				sub2.AddCommand(sub22)
+
+				return r
+			}(),
+			expectedExpressions: []string{"(sub11 sub12)", "(sub21 sub22)"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			tc.root.GenZshCompletion(buf)
+			completion := buf.String()
+			for _, expectedExpression := range tc.expectedExpressions {
+				if !strings.Contains(completion, expectedExpression) {
+					t.Errorf("expected completion to contain '%v' somewhere; got '%v'", expectedExpression, completion)
+				}
+			}
+		})
+	}
+}

--- a/vendor/github.com/spf13/pflag/.travis.yml
+++ b/vendor/github.com/spf13/pflag/.travis.yml
@@ -3,18 +3,19 @@ sudo: false
 language: go
 
 go:
-        - 1.6.3
-        - 1.7.3
-        - tip
+  - 1.7.3
+  - 1.8.1
+  - tip
 
 matrix:
-        allow_failures:
-                  - go: tip
+  allow_failures:
+    - go: tip
+
 install:
-        - go get github.com/golang/lint/golint
-        - export PATH=$GOPATH/bin:$PATH
-        - go install ./...
+  - go get github.com/golang/lint/golint
+  - export PATH=$GOPATH/bin:$PATH
+  - go install ./...
 
 script:
-        - verify/all.sh -v
-        - go test ./...
+  - verify/all.sh -v
+  - go test ./...

--- a/vendor/github.com/spf13/pflag/README.md
+++ b/vendor/github.com/spf13/pflag/README.md
@@ -246,6 +246,25 @@ It is possible to mark a flag as hidden, meaning it will still function as norma
 flags.MarkHidden("secretFlag")
 ```
 
+## Disable sorting of flags
+`pflag` allows you to disable sorting of flags for help and usage message.
+
+**Example**:
+```go
+flags.BoolP("verbose", "v", false, "verbose output")
+flags.String("coolflag", "yeaah", "it's really cool flag")
+flags.Int("usefulflag", 777, "sometimes it's very useful")
+flags.SortFlags = false
+flags.PrintDefaults()
+```
+**Output**:
+```
+  -v, --verbose           verbose output
+      --coolflag string   it's really cool flag (default "yeaah")
+      --usefulflag int    sometimes it's very useful (default 777)
+```
+
+
 ## Supporting Go flags when using pflag
 In order to support flags defined using Go's `flag` package, they must be added to the `pflag` flagset. This is usually necessary
 to support flags defined by third-party dependencies (e.g. `golang/glog`).
@@ -270,8 +289,8 @@ func main() {
 You can see the full reference documentation of the pflag package
 [at godoc.org][3], or through go's standard documentation system by
 running `godoc -http=:6060` and browsing to
-[http://localhost:6060/pkg/github.com/ogier/pflag][2] after
+[http://localhost:6060/pkg/github.com/spf13/pflag][2] after
 installation.
 
-[2]: http://localhost:6060/pkg/github.com/ogier/pflag
-[3]: http://godoc.org/github.com/ogier/pflag
+[2]: http://localhost:6060/pkg/github.com/spf13/pflag
+[3]: http://godoc.org/github.com/spf13/pflag

--- a/vendor/github.com/spf13/pflag/count.go
+++ b/vendor/github.com/spf13/pflag/count.go
@@ -83,7 +83,9 @@ func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
 	return p
 }
 
-// Count like Count only the flag is placed on the CommandLine isntead of a given flag set
+// Count defines a count flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+// A count flag will add 1 to its value evey time it is found on the command line
 func Count(name string, usage string) *int {
 	return CommandLine.CountP(name, "", usage)
 }

--- a/vendor/github.com/spf13/pflag/example_test.go
+++ b/vendor/github.com/spf13/pflag/example_test.go
@@ -2,76 +2,35 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// These examples demonstrate more intricate uses of the flag package.
 package pflag_test
 
 import (
-	"errors"
 	"fmt"
-	"strings"
-	"time"
 
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/pflag"
 )
 
-// Example 1: A single string flag called "species" with default value "gopher".
-var species = flag.String("species", "gopher", "the species we are studying")
+func ExampleShorthandLookup() {
+	name := "verbose"
+	short := name[:1]
 
-// Example 2: A flag with a shorthand letter.
-var gopherType = flag.StringP("gopher_type", "g", "pocket", "the variety of gopher")
+	pflag.BoolP(name, short, false, "verbose output")
 
-// Example 3: A user-defined flag type, a slice of durations.
-type interval []time.Duration
+	// len(short) must be == 1
+	flag := pflag.ShorthandLookup(short)
 
-// String is the method to format the flag's value, part of the flag.Value interface.
-// The String method's output will be used in diagnostics.
-func (i *interval) String() string {
-	return fmt.Sprint(*i)
+	fmt.Println(flag.Name)
 }
 
-func (i *interval) Type() string {
-	return "interval"
-}
+func ExampleFlagSet_ShorthandLookup() {
+	name := "verbose"
+	short := name[:1]
 
-// Set is the method to set the flag value, part of the flag.Value interface.
-// Set's argument is a string to be parsed to set the flag.
-// It's a comma-separated list, so we split it.
-func (i *interval) Set(value string) error {
-	// If we wanted to allow the flag to be set multiple times,
-	// accumulating values, we would delete this if statement.
-	// That would permit usages such as
-	//	-deltaT 10s -deltaT 15s
-	// and other combinations.
-	if len(*i) > 0 {
-		return errors.New("interval flag already set")
-	}
-	for _, dt := range strings.Split(value, ",") {
-		duration, err := time.ParseDuration(dt)
-		if err != nil {
-			return err
-		}
-		*i = append(*i, duration)
-	}
-	return nil
-}
+	fs := pflag.NewFlagSet("Example", pflag.ContinueOnError)
+	fs.BoolP(name, short, false, "verbose output")
 
-// Define a flag to accumulate durations. Because it has a special type,
-// we need to use the Var function and therefore create the flag during
-// init.
+	// len(short) must be == 1
+	flag := fs.ShorthandLookup(short)
 
-var intervalFlag interval
-
-func init() {
-	// Tie the command-line flag to the intervalFlag variable and
-	// set a usage message.
-	flag.Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
-}
-
-func Example() {
-	// All the interesting pieces are with the variables declared above, but
-	// to enable the flag package to see the flags defined there, one must
-	// execute, typically at the start of main (not init!):
-	//	flag.Parse()
-	// We don't run it here because this is not a main function and
-	// the testing suite has already parsed the flags.
+	fmt.Println(flag.Name)
 }

--- a/vendor/github.com/spf13/pflag/flag.go
+++ b/vendor/github.com/spf13/pflag/flag.go
@@ -16,9 +16,9 @@ pflag is a drop-in replacement of Go's native flag package. If you import
 pflag under the name "flag" then all code should continue to function
 with no changes.
 
-	import flag "github.com/ogier/pflag"
+	import flag "github.com/spf13/pflag"
 
-	There is one exception to this: if you directly instantiate the Flag struct
+There is one exception to this: if you directly instantiate the Flag struct
 there is one more field "Shorthand" that you will need to set.
 Most code never instantiates this struct directly, and instead uses
 functions such as String(), BoolVar(), and Var(), and is therefore
@@ -134,14 +134,21 @@ type FlagSet struct {
 	// a custom error handler.
 	Usage func()
 
+	// SortFlags is used to indicate, if user wants to have sorted flags in
+	// help/usage messages.
+	SortFlags bool
+
 	name              string
 	parsed            bool
 	actual            map[NormalizedName]*Flag
+	orderedActual     []*Flag
+	sortedActual      []*Flag
 	formal            map[NormalizedName]*Flag
+	orderedFormal     []*Flag
+	sortedFormal      []*Flag
 	shorthands        map[byte]*Flag
 	args              []string // arguments after flags
 	argsLenAtDash     int      // len(args) when a '--' was located when parsing, or -1 if no --
-	exitOnError       bool     // does the program exit if there's an error?
 	errorHandling     ErrorHandling
 	output            io.Writer // nil means stderr; use out() accessor
 	interspersed      bool      // allow interspersed option/non-option args
@@ -156,7 +163,7 @@ type Flag struct {
 	Value               Value               // value as set
 	DefValue            string              // default value (as text); for usage message
 	Changed             bool                // If the user set the value (or if left to default)
-	NoOptDefVal         string              //default value (as text); if the flag is on the command line without any options
+	NoOptDefVal         string              // default value (as text); if the flag is on the command line without any options
 	Deprecated          string              // If this flag is deprecated, this string is the new or now thing to use
 	Hidden              bool                // used by cobra.Command to allow flags to be hidden from help/usage text
 	ShorthandDeprecated string              // If the shorthand of this flag is deprecated, this string is the new or now thing to use
@@ -194,11 +201,13 @@ func sortFlags(flags map[NormalizedName]*Flag) []*Flag {
 // "--getUrl" which may also be translated to "geturl" and everything will work.
 func (f *FlagSet) SetNormalizeFunc(n func(f *FlagSet, name string) NormalizedName) {
 	f.normalizeNameFunc = n
-	for k, v := range f.formal {
-		delete(f.formal, k)
-		nname := f.normalizeFlagName(string(k))
-		f.formal[nname] = v
+	f.sortedFormal = f.sortedFormal[:0]
+	for k, v := range f.orderedFormal {
+		delete(f.formal, NormalizedName(v.Name))
+		nname := f.normalizeFlagName(v.Name)
 		v.Name = string(nname)
+		f.formal[nname] = v
+		f.orderedFormal[k] = v
 	}
 }
 
@@ -229,10 +238,25 @@ func (f *FlagSet) SetOutput(output io.Writer) {
 	f.output = output
 }
 
-// VisitAll visits the flags in lexicographical order, calling fn for each.
+// VisitAll visits the flags in lexicographical order or
+// in primordial order if f.SortFlags is false, calling fn for each.
 // It visits all flags, even those not set.
 func (f *FlagSet) VisitAll(fn func(*Flag)) {
-	for _, flag := range sortFlags(f.formal) {
+	if len(f.formal) == 0 {
+		return
+	}
+
+	var flags []*Flag
+	if f.SortFlags {
+		if len(f.formal) != len(f.sortedFormal) {
+			f.sortedFormal = sortFlags(f.formal)
+		}
+		flags = f.sortedFormal
+	} else {
+		flags = f.orderedFormal
+	}
+
+	for _, flag := range flags {
 		fn(flag)
 	}
 }
@@ -253,22 +277,39 @@ func (f *FlagSet) HasAvailableFlags() bool {
 	return false
 }
 
-// VisitAll visits the command-line flags in lexicographical order, calling
-// fn for each.  It visits all flags, even those not set.
+// VisitAll visits the command-line flags in lexicographical order or
+// in primordial order if f.SortFlags is false, calling fn for each.
+// It visits all flags, even those not set.
 func VisitAll(fn func(*Flag)) {
 	CommandLine.VisitAll(fn)
 }
 
-// Visit visits the flags in lexicographical order, calling fn for each.
+// Visit visits the flags in lexicographical order or
+// in primordial order if f.SortFlags is false, calling fn for each.
 // It visits only those flags that have been set.
 func (f *FlagSet) Visit(fn func(*Flag)) {
-	for _, flag := range sortFlags(f.actual) {
+	if len(f.actual) == 0 {
+		return
+	}
+
+	var flags []*Flag
+	if f.SortFlags {
+		if len(f.actual) != len(f.sortedActual) {
+			f.sortedActual = sortFlags(f.actual)
+		}
+		flags = f.sortedActual
+	} else {
+		flags = f.orderedActual
+	}
+
+	for _, flag := range flags {
 		fn(flag)
 	}
 }
 
-// Visit visits the command-line flags in lexicographical order, calling fn
-// for each.  It visits only those flags that have been set.
+// Visit visits the command-line flags in lexicographical order or
+// in primordial order if f.SortFlags is false, calling fn for each.
+// It visits only those flags that have been set.
 func Visit(fn func(*Flag)) {
 	CommandLine.Visit(fn)
 }
@@ -276,6 +317,22 @@ func Visit(fn func(*Flag)) {
 // Lookup returns the Flag structure of the named flag, returning nil if none exists.
 func (f *FlagSet) Lookup(name string) *Flag {
 	return f.lookup(f.normalizeFlagName(name))
+}
+
+// ShorthandLookup returns the Flag structure of the short handed flag,
+// returning nil if none exists.
+// It panics, if len(name) > 1.
+func (f *FlagSet) ShorthandLookup(name string) *Flag {
+	if name == "" {
+		return nil
+	}
+	if len(name) > 1 {
+		msg := fmt.Sprintf("can not look up shorthand which is more than one ASCII character: %q", name)
+		fmt.Fprintf(f.out(), msg)
+		panic(msg)
+	}
+	c := name[0]
+	return f.shorthands[c]
 }
 
 // lookup returns the Flag structure of the named flag, returning nil if none exists.
@@ -319,7 +376,7 @@ func (f *FlagSet) MarkDeprecated(name string, usageMessage string) error {
 	if flag == nil {
 		return fmt.Errorf("flag %q does not exist", name)
 	}
-	if len(usageMessage) == 0 {
+	if usageMessage == "" {
 		return fmt.Errorf("deprecated message for flag %q must be set", name)
 	}
 	flag.Deprecated = usageMessage
@@ -334,7 +391,7 @@ func (f *FlagSet) MarkShorthandDeprecated(name string, usageMessage string) erro
 	if flag == nil {
 		return fmt.Errorf("flag %q does not exist", name)
 	}
-	if len(usageMessage) == 0 {
+	if usageMessage == "" {
 		return fmt.Errorf("deprecated message for flag %q must be set", name)
 	}
 	flag.ShorthandDeprecated = usageMessage
@@ -358,6 +415,12 @@ func Lookup(name string) *Flag {
 	return CommandLine.Lookup(name)
 }
 
+// ShorthandLookup returns the Flag structure of the short handed flag,
+// returning nil if none exists.
+func ShorthandLookup(name string) *Flag {
+	return CommandLine.ShorthandLookup(name)
+}
+
 // Set sets the value of the named flag.
 func (f *FlagSet) Set(name, value string) error {
 	normalName := f.normalizeFlagName(name)
@@ -365,17 +428,28 @@ func (f *FlagSet) Set(name, value string) error {
 	if !ok {
 		return fmt.Errorf("no such flag -%v", name)
 	}
+
 	err := flag.Value.Set(value)
 	if err != nil {
-		return err
+		var flagName string
+		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
+			flagName = fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name)
+		} else {
+			flagName = fmt.Sprintf("--%s", flag.Name)
+		}
+		return fmt.Errorf("invalid argument %q for %q flag: %v", value, flagName, err)
 	}
+
 	if f.actual == nil {
 		f.actual = make(map[NormalizedName]*Flag)
 	}
 	f.actual[normalName] = flag
+	f.orderedActual = append(f.orderedActual, flag)
+
 	flag.Changed = true
-	if len(flag.Deprecated) > 0 {
-		fmt.Fprintf(os.Stderr, "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+
+	if flag.Deprecated != "" {
+		fmt.Fprintf(f.out(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
 	}
 	return nil
 }
@@ -557,28 +631,28 @@ func wrap(i, w int, s string) string {
 // for all flags in the FlagSet. Wrapped to `cols` columns (0 for no
 // wrapping)
 func (f *FlagSet) FlagUsagesWrapped(cols int) string {
-	x := new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 
 	lines := make([]string, 0, len(f.formal))
 
 	maxlen := 0
 	f.VisitAll(func(flag *Flag) {
-		if len(flag.Deprecated) > 0 || flag.Hidden {
+		if flag.Deprecated != "" || flag.Hidden {
 			return
 		}
 
 		line := ""
-		if len(flag.Shorthand) > 0 && len(flag.ShorthandDeprecated) == 0 {
+		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
 			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
 		} else {
 			line = fmt.Sprintf("      --%s", flag.Name)
 		}
 
 		varname, usage := UnquoteUsage(flag)
-		if len(varname) > 0 {
+		if varname != "" {
 			line += " " + varname
 		}
-		if len(flag.NoOptDefVal) > 0 {
+		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":
 				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
@@ -601,7 +675,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		line += usage
 		if !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default \"%s\")", flag.DefValue)
+				line += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}
@@ -614,10 +688,10 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		sidx := strings.Index(line, "\x00")
 		spacing := strings.Repeat(" ", maxlen-sidx)
 		// maxlen + 2 comes from + 1 for the \x00 and + 1 for the (deliberate) off-by-one in maxlen-sidx
-		fmt.Fprintln(x, line[:sidx], spacing, wrap(maxlen+2, cols, line[sidx+1:]))
+		fmt.Fprintln(buf, line[:sidx], spacing, wrap(maxlen+2, cols, line[sidx+1:]))
 	}
 
-	return x.String()
+	return buf.String()
 }
 
 // FlagUsages returns a string containing the usage information for all flags in
@@ -714,11 +788,10 @@ func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
 
 // AddFlag will add the flag to the FlagSet
 func (f *FlagSet) AddFlag(flag *Flag) {
-	// Call normalizeFlagName function only once
 	normalizedFlagName := f.normalizeFlagName(flag.Name)
 
-	_, alreadythere := f.formal[normalizedFlagName]
-	if alreadythere {
+	_, alreadyThere := f.formal[normalizedFlagName]
+	if alreadyThere {
 		msg := fmt.Sprintf("%s flag redefined: %s", f.name, flag.Name)
 		fmt.Fprintln(f.out(), msg)
 		panic(msg) // Happens only if flags are declared with identical names
@@ -729,28 +802,31 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 
 	flag.Name = string(normalizedFlagName)
 	f.formal[normalizedFlagName] = flag
+	f.orderedFormal = append(f.orderedFormal, flag)
 
-	if len(flag.Shorthand) == 0 {
+	if flag.Shorthand == "" {
 		return
 	}
 	if len(flag.Shorthand) > 1 {
-		fmt.Fprintf(f.out(), "%s shorthand more than ASCII character: %s\n", f.name, flag.Shorthand)
-		panic("shorthand is more than one character")
+		msg := fmt.Sprintf("%q shorthand is more than one ASCII character", flag.Shorthand)
+		fmt.Fprintf(f.out(), msg)
+		panic(msg)
 	}
 	if f.shorthands == nil {
 		f.shorthands = make(map[byte]*Flag)
 	}
 	c := flag.Shorthand[0]
-	old, alreadythere := f.shorthands[c]
-	if alreadythere {
-		fmt.Fprintf(f.out(), "%s shorthand reused: %q for %s already used for %s\n", f.name, c, flag.Name, old.Name)
-		panic("shorthand redefinition")
+	used, alreadyThere := f.shorthands[c]
+	if alreadyThere {
+		msg := fmt.Sprintf("unable to redefine %q shorthand in %q flagset: it's already used for %q flag", c, f.name, used.Name)
+		fmt.Fprintf(f.out(), msg)
+		panic(msg)
 	}
 	f.shorthands[c] = flag
 }
 
 // AddFlagSet adds one FlagSet to another. If a flag is already present in f
-// the flag from newSet will be ignored
+// the flag from newSet will be ignored.
 func (f *FlagSet) AddFlagSet(newSet *FlagSet) {
 	if newSet == nil {
 		return
@@ -798,34 +874,6 @@ func (f *FlagSet) usage() {
 	}
 }
 
-func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
-	if err := flag.Value.Set(value); err != nil {
-		return f.failf("invalid argument %q for %s: %v", value, origArg, err)
-	}
-	// mark as visited for Visit()
-	if f.actual == nil {
-		f.actual = make(map[NormalizedName]*Flag)
-	}
-	f.actual[f.normalizeFlagName(flag.Name)] = flag
-	flag.Changed = true
-	if len(flag.Deprecated) > 0 {
-		fmt.Fprintf(os.Stderr, "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
-	}
-	if len(flag.ShorthandDeprecated) > 0 && containsShorthand(origArg, flag.Shorthand) {
-		fmt.Fprintf(os.Stderr, "Flag shorthand -%s has been deprecated, %s\n", flag.Shorthand, flag.ShorthandDeprecated)
-	}
-	return nil
-}
-
-func containsShorthand(arg, shorthand string) bool {
-	// filter out flags --<flag_name>
-	if strings.HasPrefix(arg, "-") {
-		return false
-	}
-	arg = strings.SplitN(arg, "=", 2)[0]
-	return strings.Contains(arg, shorthand)
-}
-
 func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []string, err error) {
 	a = args
 	name := s[2:]
@@ -833,10 +881,11 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 		err = f.failf("bad flag syntax: %s", s)
 		return
 	}
+
 	split := strings.SplitN(name, "=", 2)
 	name = split[0]
-	flag, alreadythere := f.formal[f.normalizeFlagName(name)]
-	if !alreadythere {
+	flag, exists := f.formal[f.normalizeFlagName(name)]
+	if !exists {
 		if name == "help" { // special case for nice help message.
 			f.usage()
 			return a, ErrHelp
@@ -844,11 +893,12 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 		err = f.failf("unknown flag: --%s", name)
 		return
 	}
+
 	var value string
 	if len(split) == 2 {
 		// '--flag=arg'
 		value = split[1]
-	} else if len(flag.NoOptDefVal) > 0 {
+	} else if flag.NoOptDefVal != "" {
 		// '--flag' (arg was optional)
 		value = flag.NoOptDefVal
 	} else if len(a) > 0 {
@@ -860,7 +910,8 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 		err = f.failf("flag needs an argument: %s", s)
 		return
 	}
-	err = fn(flag, value, s)
+
+	err = fn(flag, value)
 	return
 }
 
@@ -868,38 +919,49 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 	if strings.HasPrefix(shorthands, "test.") {
 		return
 	}
+
 	outArgs = args
 	outShorts = shorthands[1:]
 	c := shorthands[0]
 
-	flag, alreadythere := f.shorthands[c]
-	if !alreadythere {
+	flag, exists := f.shorthands[c]
+	if !exists {
 		if c == 'h' { // special case for nice help message.
 			f.usage()
 			err = ErrHelp
 			return
 		}
-		//TODO continue on error
 		err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
 		return
 	}
+
 	var value string
 	if len(shorthands) > 2 && shorthands[1] == '=' {
+		// '-f=arg'
 		value = shorthands[2:]
 		outShorts = ""
-	} else if len(flag.NoOptDefVal) > 0 {
+	} else if flag.NoOptDefVal != "" {
+		// '-f' (arg was optional)
 		value = flag.NoOptDefVal
 	} else if len(shorthands) > 1 {
+		// '-farg'
 		value = shorthands[1:]
 		outShorts = ""
 	} else if len(args) > 0 {
+		// '-f arg'
 		value = args[0]
 		outArgs = args[1:]
 	} else {
+		// '-f' (arg was required)
 		err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
 		return
 	}
-	err = fn(flag, value, shorthands)
+
+	if flag.ShorthandDeprecated != "" {
+		fmt.Fprintf(f.out(), "Flag shorthand -%s has been deprecated, %s\n", flag.Shorthand, flag.ShorthandDeprecated)
+	}
+
+	err = fn(flag, value)
 	return
 }
 
@@ -907,6 +969,7 @@ func (f *FlagSet) parseShortArg(s string, args []string, fn parseFunc) (a []stri
 	a = args
 	shorthands := s[1:]
 
+	// "shorthands" can be a series of shorthand letters of flags (e.g. "-vvv").
 	for len(shorthands) > 0 {
 		shorthands, a, err = f.parseSingleShortArg(shorthands, args, fn)
 		if err != nil {
@@ -954,13 +1017,18 @@ func (f *FlagSet) parseArgs(args []string, fn parseFunc) (err error) {
 // The return value will be ErrHelp if -help was set but not defined.
 func (f *FlagSet) Parse(arguments []string) error {
 	f.parsed = true
-	f.args = make([]string, 0, len(arguments))
 
-	assign := func(flag *Flag, value, origArg string) error {
-		return f.setFlag(flag, value, origArg)
+	if len(arguments) < 0 {
+		return nil
 	}
 
-	err := f.parseArgs(arguments, assign)
+	f.args = make([]string, 0, len(arguments))
+
+	set := func(flag *Flag, value string) error {
+		return f.Set(flag.Name, value)
+	}
+
+	err := f.parseArgs(arguments, set)
 	if err != nil {
 		switch f.errorHandling {
 		case ContinueOnError:
@@ -974,7 +1042,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 	return nil
 }
 
-type parseFunc func(flag *Flag, value, origArg string) error
+type parseFunc func(flag *Flag, value string) error
 
 // ParseAll parses flag definitions from the argument list, which should not
 // include the command name. The arguments for fn are flag and value. Must be
@@ -985,11 +1053,7 @@ func (f *FlagSet) ParseAll(arguments []string, fn func(flag *Flag, value string)
 	f.parsed = true
 	f.args = make([]string, 0, len(arguments))
 
-	assign := func(flag *Flag, value, origArg string) error {
-		return fn(flag, value)
-	}
-
-	err := f.parseArgs(arguments, assign)
+	err := f.parseArgs(arguments, fn)
 	if err != nil {
 		switch f.errorHandling {
 		case ContinueOnError:
@@ -1036,14 +1100,15 @@ func Parsed() bool {
 // CommandLine is the default set of command-line flags, parsed from os.Args.
 var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
 
-// NewFlagSet returns a new, empty flag set with the specified name and
-// error handling property.
+// NewFlagSet returns a new, empty flag set with the specified name,
+// error handling property and SortFlags set to true.
 func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
 	f := &FlagSet{
 		name:          name,
 		errorHandling: errorHandling,
 		argsLenAtDash: -1,
 		interspersed:  true,
+		SortFlags:     true,
 	}
 	return f
 }


### PR DESCRIPTION
```console
$ svcat provision --help
Create a new instance of a service

Usage:
  svcat provision NAME --plan PLAN --class CLASS [flags]

Examples:

  svcat provision wordpress-mysql-instance --class azure-mysqldb --plan standard800 -p location=eastus -p sslEnforcement=disabled
  svcat provision wordpress-mysql-instance --class azure-mysqldb --plan standard800 -s mysecret[dbparams]


Flags:
      --class string         The class name (Required)
  -h, --help                 help for provision
  -n, --namespace string     The namespace in which to create the instance (default "default")
  -p, --param stringArray    Additional parameter to use when provisioning the service, format: NAME=VALUE
      --plan string          The plan name (Required)
  -s, --secret stringArray   Additional parameter, whose value is stored in a secret, to use when provisioning the service, format: SECRET[KEY]
```
Closes #79 