### PR TITLE
Add deprovision command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Broker:
   Status:   Ready
 ```
 
+## Delete a service instance
+Deprovisioning is the process of preparing an instance to be removed, and then deleting it.
+
+```console
+$ svcat deprovision ponycms-wordpress-mysql-instance
+```
+
 # Contributing
 
 For details on how to contribute to this project, please see

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -75,6 +75,7 @@ func buildRootCommand() *cobra.Command {
 	cmd.AddCommand(newGetCmd(cxt))
 	cmd.AddCommand(newDescribeCmd(cxt))
 	cmd.AddCommand(instance.NewProvisionCmd(cxt))
+	cmd.AddCommand(instance.NewDeprovisionCmd(cxt))
 	cmd.AddCommand(newSyncCmd(cxt))
 
 	return cmd

--- a/pkg/instance/deprovision_cmd.go
+++ b/pkg/instance/deprovision_cmd.go
@@ -1,0 +1,44 @@
+package instance
+
+import (
+	"fmt"
+
+	"github.com/Azure/service-catalog-cli/pkg/command"
+	"github.com/spf13/cobra"
+)
+
+type deprovisonCmd struct {
+	*command.Context
+	ns string
+}
+
+// NewDeprovisionCmd builds a "svcat deprovision" command
+func NewDeprovisionCmd(cxt *command.Context) *cobra.Command {
+	deprovisonCmd := &deprovisonCmd{Context: cxt}
+	cmd := &cobra.Command{
+		Use:   "deprovision NAME",
+		Short: "Deletes an instance of a service",
+		Example: `
+  svcat deprovision wordpress-mysql-instance
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deprovisonCmd.run(args)
+		},
+	}
+	cmd.Flags().StringVarP(&deprovisonCmd.ns, "namespace", "n", "default",
+		"The namespace of the instance")
+	return cmd
+}
+
+func (c *deprovisonCmd) run(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("name is required")
+	}
+
+	key := args[0]
+	return c.deprovision(key)
+}
+
+func (c *deprovisonCmd) deprovision(instanceName string) error {
+	return deprovision(c.Client, c.ns, instanceName)
+}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -67,3 +67,12 @@ func provision(cl *clientset.Clientset, namespace, instanceName, className, plan
 	}
 	return result, nil
 }
+
+func deprovision(cl *clientset.Clientset, namespace, instanceName string) error {
+	err := cl.ServicecatalogV1beta1().ServiceInstances(namespace).Delete(instanceName, &v1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("deprovision request failed (%s)", err)
+	}
+	return nil
+}
+


### PR DESCRIPTION
Closes #80 
  
```console
$ svcat deprovision --help
Deletes an instance of a service

Usage:
  svcat deprovision NAME [flags]

Examples:

  svcat deprovision wordpress-mysql-instance


Flags:
  -h, --help               help for deprovision
  -n, --namespace string   The namespace of the instance (default "default")
```