### PR TITLE
Add bind command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ Plans:
 $ svcat provision quickstart-wordpress-mysql-instance \
     --class azure-mysqldb --plan standard800 \
     -p location=eastus -p resourceGroup=default
+    -p sslEnforcement=disabled \
+    -p firewallStartIPAddress=0.0.0.0 \
+    -p firewallEndIPAddress=255.255.255.255
 ```
 
 ## View all instances of a service plan on the cluster

--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ $ svcat get bindings --namespace cms
   ponycms-wordpress-mysql-binding    cms         ponycms-wordpress-mysql-instance    Ready
 ```
 
+## Bind an instance
+
+```console
+$ svcat bind quickstart-wordpress-mysql-instance
+    --name quickstart-wordpress-mysql-binding \
+    --secret-name quickstart-wordpress-secret
+```
+
+When omitted, the names of the binding and secret are defaulted to the name of the instance.
+
+```console
+$ svcat bind wordpress-mysql
+```
+
 ## View the details of a service instance
 
 ```console

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -75,6 +75,7 @@ func buildRootCommand() *cobra.Command {
 	cmd.AddCommand(newGetCmd(cxt))
 	cmd.AddCommand(newDescribeCmd(cxt))
 	cmd.AddCommand(instance.NewProvisionCmd(cxt))
+	cmd.AddCommand(binding.NewBindCmd(cxt))
 	cmd.AddCommand(newSyncCmd(cxt))
 
 	return cmd

--- a/pkg/binding/bind_cmd.go
+++ b/pkg/binding/bind_cmd.go
@@ -68,6 +68,12 @@ func (c *bindCmd) run(args []string) error {
 	}
 	c.instanceName = args[0]
 
+	// Manually defaulting the name of the binding
+	// I'm not doing the same for the secret since the API handles defaulting that value.
+	if c.bindingName == "" {
+		c.bindingName = c.instanceName
+	}
+
 	params, err := parameters.ParseVariableAssignments(c.params)
 	if err != nil {
 		return fmt.Errorf("invalid --param value (%s)", err)

--- a/pkg/binding/bind_cmd.go
+++ b/pkg/binding/bind_cmd.go
@@ -1,0 +1,93 @@
+package binding
+
+import (
+	"fmt"
+
+	"github.com/Azure/service-catalog-cli/pkg/command"
+	"github.com/Azure/service-catalog-cli/pkg/output"
+	"github.com/Azure/service-catalog-cli/pkg/parameters"
+	"github.com/spf13/cobra"
+)
+
+type bindCmd struct {
+	*command.Context
+	ns           string
+	instanceName string
+	bindingName  string
+	secretName   string
+	params       []string
+	secrets      []string
+}
+
+// NewBindCmd builds a "svcat bind" command
+func NewBindCmd(cxt *command.Context) *cobra.Command {
+	bindCmd := &bindCmd{Context: cxt}
+	cmd := &cobra.Command{
+		Use:   "bind INSTANCE_NAME",
+		Short: "Binds an instance's metadata to a secret, which can then be used by an application to connect to the instance",
+		Example: `
+  svcat bind wordpress
+  svcat bind wordpress-mysql-instance --name wordpress-mysql-binding --secret-name wordpress-mysql-secret
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bindCmd.run(args)
+		},
+	}
+	cmd.Flags().StringVarP(
+		&bindCmd.ns,
+		"namespace",
+		"n",
+		"default",
+		"The instance namespace",
+	)
+	cmd.Flags().StringVarP(
+		&bindCmd.bindingName,
+		"name",
+		"",
+		"",
+		"The name of the binding. Defaults to the name of the instance.",
+	)
+	cmd.Flags().StringVarP(
+		&bindCmd.secretName,
+		"secret-name",
+		"",
+		"",
+		"The name of the secret. Defaults to the name of the instance.",
+	)
+	cmd.Flags().StringArrayVarP(&bindCmd.params, "param", "p", nil,
+		"Additional parameter to use when binding the instance, format: NAME=VALUE")
+	cmd.Flags().StringArrayVarP(&bindCmd.secrets, "secret", "s", nil,
+		"Additional parameter, whose value is stored in a secret, to use when binding the instance, format: SECRET[KEY]")
+
+	return cmd
+}
+
+func (c *bindCmd) run(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("instance is required")
+	}
+	c.instanceName = args[0]
+
+	params, err := parameters.ParseVariableAssignments(c.params)
+	if err != nil {
+		return fmt.Errorf("invalid --param value (%s)", err)
+	}
+
+	secrets, err := parameters.ParseKeyMaps(c.secrets)
+	if err != nil {
+		return fmt.Errorf("invalid --secret value (%s)", err)
+	}
+
+	return c.bind(params, secrets)
+}
+
+func (c *bindCmd) bind(params map[string]string, secrets map[string]string) error {
+	binding, err := bind(c.Client, c.ns, c.bindingName, c.instanceName, c.secretName, params, secrets)
+	if err != nil {
+		return err
+	}
+
+	output.WriteBindingDetails(c.Output, binding)
+
+	return nil
+}

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -3,6 +3,7 @@ package binding
 import (
 	"fmt"
 
+	"github.com/Azure/service-catalog-cli/pkg/client"
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +12,7 @@ import (
 func retrieveAll(cl *clientset.Clientset, ns string) (*v1beta1.ServiceBindingList, error) {
 	bindings, err := cl.ServicecatalogV1beta1().ServiceBindings(ns).List(v1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Error listing bindings (%s)", err)
+		return nil, fmt.Errorf("unable to list bindings in %s (%s)", ns, err)
 	}
 
 	return bindings, nil
@@ -23,4 +24,29 @@ func retrieveByName(cl *clientset.Clientset, ns, name string) (*v1beta1.ServiceB
 		return nil, fmt.Errorf("unable to get binding '%s.%s' (%+v)", ns, name, err)
 	}
 	return binding, nil
+}
+
+func bind(cl *clientset.Clientset, namespace, bindingName, instanceName, secretName string,
+	params map[string]string, secrets map[string]string) (*v1beta1.ServiceBinding, error) {
+	request := &v1beta1.ServiceBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      bindingName,
+			Namespace: namespace,
+		},
+		Spec: v1beta1.ServiceBindingSpec{
+			ServiceInstanceRef: v1beta1.LocalObjectReference{
+				Name: instanceName,
+			},
+			SecretName:     secretName,
+			Parameters:     client.BuildParameters(params),
+			ParametersFrom: client.BuildParametersFrom(secrets),
+		},
+	}
+
+	result, err := cl.ServicecatalogV1beta1().ServiceBindings(namespace).Create(request)
+	if err != nil {
+		return nil, fmt.Errorf("bind request failed (%s)", err)
+	}
+
+	return result, nil
 }

--- a/pkg/binding/describe_cmd.go
+++ b/pkg/binding/describe_cmd.go
@@ -50,9 +50,9 @@ func (c *describeCmd) run(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("name is required")
 	}
+	name := args[0]
 
-	key := args[0]
-	return c.describe(key)
+	return c.describe(name)
 }
 
 func (c *describeCmd) describe(name string) error {

--- a/pkg/client/parameters.go
+++ b/pkg/client/parameters.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// BuildParameters converts a map of variable assignments to a byte encoded json document,
+// which is what the ServiceCatalog API consumes.
+func BuildParameters(params map[string]string) *runtime.RawExtension {
+	paramsJson, err := json.Marshal(params)
+	if err != nil {
+		// This should never be hit because marshalling a map[string]string is pretty safe
+		// I'd rather throw a panic then force handling of an error that I don't think is possible.
+		panic(fmt.Errorf("unable to marshal the request parameters %v (%s)", params, err))
+	}
+
+	return &runtime.RawExtension{Raw: paramsJson}
+}
+
+// BuildParametersFrom converts a map of secrets names to secret keys to the
+// type consumed by the ServiceCatalog API.
+func BuildParametersFrom(secrets map[string]string) []v1beta1.ParametersFromSource {
+	params := make([]v1beta1.ParametersFromSource, 0, len(secrets))
+
+	for secret, key := range secrets {
+		param := v1beta1.ParametersFromSource{
+			SecretKeyRef: &v1beta1.SecretKeyReference{
+				Name: secret,
+				Key:  key,
+			},
+		}
+
+		params = append(params, param)
+	}
+
+	return params
+}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -12,7 +12,7 @@ import (
 func retrieveAll(cl *clientset.Clientset, ns string) (*v1beta1.ServiceInstanceList, error) {
 	instances, err := cl.ServicecatalogV1beta1().ServiceInstances(ns).List(v1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Error listing instances (%s)", err)
+		return nil, fmt.Errorf("unable to list instances in %s (%s)", ns, err)
 	}
 
 	return instances, nil


### PR DESCRIPTION
Closes #81 

```console
$ svcat bind --help
Binds an instance's metadata to a secret, which can then be used by an application to connect to the instance

Usage:
  svcat bind INSTANCE_NAME [flags]

Examples:

  svcat bind wordpress
  svcat bind wordpress-mysql-instance --name wordpress-mysql-binding --secret-name wordpress-mysql-secret


Flags:
  -h, --help                 help for bind
      --name string          The name of the binding. Defaults to the name of the instance.
  -n, --namespace string     The instance namespace (default "default")
  -p, --param stringArray    Additional parameter to use when binding the instance, format: NAME=VALUE
  -s, --secret stringArray   Additional parameter, whose value is stored in a secret, to use when binding the instance, format: SECRET[KEY]
      --secret-name string   The name of the secret. Defaults to the name of the instance.
```